### PR TITLE
Change metadata to return image URLs instead of base64

### DIFF
--- a/src/controllers/MetaDataController.test.ts
+++ b/src/controllers/MetaDataController.test.ts
@@ -176,12 +176,14 @@ describe('MetaDataController', () => {
         },
         ownerAddress: '0xa59C818Ddb801f1253edEbf0Cf08c9E481EA2fE5',
       });
-      const expectedImageUrl = '/image-src/matt.crypto';
+      // supertest api runs on localhost with random port
+      const expectedImageUrl =
+        /^http:\/\/127.0.0.1:\d*\/image-src\/matt.crypto$/;
       const response = await supertest(api)
         .get(`/metadata/${domain.name}`)
         .send()
         .then((r) => r.body);
-      expect(response.image).to.equal(expectedImageUrl);
+      expect(response.image).to.match(expectedImageUrl);
       expect(response.attributes).to.deep.equal([
         { trait_type: 'domain', value: 'matt.crypto' },
         { trait_type: 'level', value: 2 },

--- a/src/controllers/MetaDataController.ts
+++ b/src/controllers/MetaDataController.ts
@@ -147,7 +147,9 @@ export class MetaDataController {
       },
       external_url: `https://unstoppabledomains.com/search?searchTerm=${domain.name}`,
       image: hasPicture
-        ? `${request.baseUrl}/image-src/${domain.name}`
+        ? `${request.protocol}://${request.get('host')}/image-src/${
+            domain.name
+          }`
         : this.generateDomainImageUrl(domain.name),
       attributes: domainAttributes,
     };


### PR DESCRIPTION
## Related story
https://www.pivotaltracker.com/story/show/180168262

## Changes
 - Changed the metadata endpoint to return image urls. Instead of base64 image data it returns a link to metadata `/image-src` endpoint which renders the image
 - Metadata endpoint doesn't pull image data, just checks if a custom image exists

## Notes
Should be merged after #50 