### PR TITLE
Add parallel tx processing

### DIFF
--- a/src/models/CnsRegistryEvent.ts
+++ b/src/models/CnsRegistryEvent.ts
@@ -133,9 +133,11 @@ export default class CnsRegistryEvent extends Model {
 
   async beforeValidate(): Promise<void> {
     const tokenId = this.tokenId();
-    this.node = tokenId
-      ? CnsRegistryEvent.tokenIdToNode(BigNumber.from(tokenId))
-      : null;
+    if (!this.node || this.node != tokenId) {
+      this.node = tokenId
+        ? CnsRegistryEvent.tokenIdToNode(BigNumber.from(tokenId))
+        : null;
+    }
   }
 
   async consistentBlockNumberForHash(): Promise<boolean> {

--- a/src/workers/eth/EthUpdater.ts
+++ b/src/workers/eth/EthUpdater.ts
@@ -395,6 +395,22 @@ export class EthUpdater {
     }
   }
 
+  private async sortAndProcessEvents(events: Event[], manager: EntityManager) {
+    const nodeEventsMap: Record<string, Event[]> = {};
+    for (const event of events) {
+      const tokenId = event.args?.tokenId || event.args?.[0];
+      if (nodeEventsMap[tokenId] === undefined) {
+        nodeEventsMap[tokenId] = [];
+      }
+      nodeEventsMap[tokenId].push(event);
+    }
+    const promises = [];
+    for (const nodeEvents of Object.values(nodeEventsMap)) {
+      promises.push(this.processEvents(nodeEvents, manager, true));
+    }
+    return Promise.all(promises);
+  }
+
   private async findLastMatchingBlock(): Promise<{
     blockNumber: number;
     blockHash: string;
@@ -569,7 +585,7 @@ export class EthUpdater {
         );
 
         await getConnection().transaction(async (manager) => {
-          await this.processEvents(events, manager);
+          await this.sortAndProcessEvents(events, manager);
           this.currentSyncBlock = fetchBlock;
           this.currentSyncBlockHash = (
             await this.provider.getBlock(this.currentSyncBlock)


### PR DESCRIPTION
## Related story
https://www.pivotaltracker.com/story/show/178148735

## Background
The initial sync of resolution service is very slow. Additionally, resolution service falls behind Polygon network if there are lots of events happening over a long period of time. 

## Changes
 - Added parallel processing of events for each domain

## Notes
Some potential improvements that can be made on top of this
 - Separate collection and processing of events (save event first, then process event)
 - Profiling/Optimization of DB queries
Also some additional testing would be good. I've only tested this on initial sync on Polygon starting from around block 22100000 where we had a spike of events.