### PR TITLE
Support Postgres SSL connections and fix colorize env parameter

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 /node_modules
 /build
+.git

--- a/src/env.ts
+++ b/src/env.ts
@@ -138,6 +138,7 @@ export const env = {
     username: process.env.RESOLUTION_POSTGRES_USERNAME,
     password: process.env.RESOLUTION_POSTGRES_PASSWORD,
     database: process.env.RESOLUTION_POSTGRES_DATABASE,
+    ssl: undefined,
     port: Number(process.env.RESOLUTION_POSTGRES_PORT || 5432),
     entities: [
       path.join(__dirname, './models/index.ts'),
@@ -158,7 +159,7 @@ export const env = {
 };
 
 if (process.env.RESOLUTION_POSTGRES_SSL) {
-  env.TYPEORM['ssl'] = {
+  env.TYPEORM.ssl = {
     rejectUnauthorized: false
   };
 }

--- a/src/env.ts
+++ b/src/env.ts
@@ -131,16 +131,21 @@ export const env = {
   },
   TYPEORM: {
     LOGGING: {
-      colorize: process.env.TYPEORM_LOGGING_COLORIZE == null ? true : process.env.TYPEORM_LOGGING_COLORIZE.toLowerCase() == 'true',
+      colorize:
+        process.env.TYPEORM_LOGGING_COLORIZE == null
+          ? true
+          : process.env.TYPEORM_LOGGING_COLORIZE.toLowerCase() == 'true',
     },
     type: 'postgres' as const,
     host: process.env.RESOLUTION_POSTGRES_HOST,
     username: process.env.RESOLUTION_POSTGRES_USERNAME,
     password: process.env.RESOLUTION_POSTGRES_PASSWORD,
     database: process.env.RESOLUTION_POSTGRES_DATABASE,
-    ssl: process.env.RESOLUTION_POSTGRES_SSL ? {
-      rejectUnauthorized: false
-    } : undefined,
+    ssl: process.env.RESOLUTION_POSTGRES_SSL
+      ? {
+          rejectUnauthorized: false,
+        }
+      : undefined,
     port: Number(process.env.RESOLUTION_POSTGRES_PORT || 5432),
     entities: [
       path.join(__dirname, './models/index.ts'),

--- a/src/env.ts
+++ b/src/env.ts
@@ -134,9 +134,6 @@ export const env = {
       colorize: process.env.TYPEORM_LOGGING_COLORIZE == null ? true : process.env.TYPEORM_LOGGING_COLORIZE.toLowerCase() == 'true',
     },
     type: 'postgres' as const,
-    ssl: {
-      rejectUnauthorized: false
-    },
     host: process.env.RESOLUTION_POSTGRES_HOST,
     username: process.env.RESOLUTION_POSTGRES_USERNAME,
     password: process.env.RESOLUTION_POSTGRES_PASSWORD,
@@ -159,3 +156,9 @@ export const env = {
     },
   },
 };
+
+if (process.env.RESOLUTION_POSTGRES_SSL) {
+  env.TYPEORM['ssl'] = {
+    rejectUnauthorized: false
+  };
+}

--- a/src/env.ts
+++ b/src/env.ts
@@ -131,9 +131,12 @@ export const env = {
   },
   TYPEORM: {
     LOGGING: {
-      colorize: process.env.TYPEORM_LOGGING_COLORIZE || true,
+      colorize: process.env.TYPEORM_LOGGING_COLORIZE == null ? true || process.env.TYPEORM_LOGGING_COLORIZE == 'true',
     },
     type: 'postgres' as const,
+    ssl: {
+      rejectUnauthorized: false
+    },
     host: process.env.RESOLUTION_POSTGRES_HOST,
     username: process.env.RESOLUTION_POSTGRES_USERNAME,
     password: process.env.RESOLUTION_POSTGRES_PASSWORD,

--- a/src/env.ts
+++ b/src/env.ts
@@ -131,7 +131,7 @@ export const env = {
   },
   TYPEORM: {
     LOGGING: {
-      colorize: process.env.TYPEORM_LOGGING_COLORIZE == null ? true || process.env.TYPEORM_LOGGING_COLORIZE == 'true',
+      colorize: process.env.TYPEORM_LOGGING_COLORIZE == null ? true : process.env.TYPEORM_LOGGING_COLORIZE.toLowerCase() == 'true',
     },
     type: 'postgres' as const,
     ssl: {

--- a/src/env.ts
+++ b/src/env.ts
@@ -138,7 +138,9 @@ export const env = {
     username: process.env.RESOLUTION_POSTGRES_USERNAME,
     password: process.env.RESOLUTION_POSTGRES_PASSWORD,
     database: process.env.RESOLUTION_POSTGRES_DATABASE,
-    ssl: undefined,
+    ssl: process.env.RESOLUTION_POSTGRES_SSL ? {
+      rejectUnauthorized: false
+    } : undefined,
     port: Number(process.env.RESOLUTION_POSTGRES_PORT || 5432),
     entities: [
       path.join(__dirname, './models/index.ts'),
@@ -157,9 +159,3 @@ export const env = {
     },
   },
 };
-
-if (process.env.RESOLUTION_POSTGRES_SSL) {
-  env.TYPEORM.ssl = {
-    rejectUnauthorized: false
-  };
-}


### PR DESCRIPTION
- `TYPEORM_LOGGING_COLORIZE` was always true because any env string value is treated as truthy, explicitly compare to `true`
- if `RESOLUTION_POSTGRES_SSL` is set, then enable SSL on the database connection
- when building the docker image, ignore the `.git` repository folder


Also, I emailed for a API key to the actual service, can I have API key granted please?
I also couldn't figure out how to get VIEWBLOCK api working, their free API key is kinda shit and just throttles you immediately. 

Is there alternative RPC provider for Zilliqa other than viewblocks?