### PR TITLE
Check NFT ownership + use image_url instead of data

### DIFF
--- a/src/controllers/MetaDataController.ts
+++ b/src/controllers/MetaDataController.ts
@@ -367,6 +367,7 @@ export class MetaDataController {
     let image = '';
     let fetchedMetadata;
     let tokenIdMetadata;
+    let validNftPfp = false;
 
     if (options.chain && options.address && options.token_id) {
       try {
@@ -377,8 +378,15 @@ export class MetaDataController {
         logger.error(error);
       }
     }
-
-    if (tokenIdMetadata?.metadata) {
+    if (
+      resolution?.ownerAddress &&
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (tokenIdMetadata as any)?.owner_of.toLowerCase() ===
+        resolution.ownerAddress.toLowerCase()
+    ) {
+      validNftPfp = true;
+    }
+    if (validNftPfp && tokenIdMetadata?.metadata) {
       try {
         fetchedMetadata = JSON.parse(tokenIdMetadata.metadata);
         image = fetchedMetadata?.image;
@@ -387,26 +395,31 @@ export class MetaDataController {
       }
     }
 
-    if (!image && !!tokenIdMetadata?.token_uri) {
+    if (validNftPfp && !image && !!tokenIdMetadata?.token_uri) {
       const response = await fetch(tokenIdMetadata.token_uri, {
         timeout: 5000,
       });
       fetchedMetadata = await response.json();
-      image = fetchedMetadata?.image;
+      image = fetchedMetadata?.image || fetchedMetadata?.image_url;
     }
     let socialPicture = '';
+    if (validNftPfp && !!image && withOverlay) {
+      const {
+        base64: backgroundImageData,
+        imageUrl: backgroundImageUrl,
+        mimeType,
+      } = await getNFTSocialPicture(image).catch(() => ({
+        base64: '',
+        imageUrl: '',
+        mimeType: null,
+      }));
 
-    if (!!image && withOverlay) {
-      const [data, mimeType] = await getNFTSocialPicture(image).catch(() => [
-        '',
-        null,
-      ]);
-
-      if (data) {
+      if (backgroundImageData || backgroundImageUrl) {
         // adding the overlay
         socialPicture = createSocialPictureImage(
           domain,
-          data,
+          backgroundImageData,
+          backgroundImageUrl,
           mimeType,
           fetchedMetadata?.background_color || '',
           raw,

--- a/src/utils/socialPicture/index.ts
+++ b/src/utils/socialPicture/index.ts
@@ -50,6 +50,7 @@ export const getNFTSocialPicture = async (
     const base64 = pictureOrUrl.substring(pictureOrUrl.indexOf('base64,') + 7);
     return { base64, imageUrl: '', mimeType };
   }
+  // Optional fetch to see if NFT image url is responsive
   const resp = await nodeFetch(makeImageLink(pictureOrUrl), { timeout: 5000 });
   if (!resp.ok) {
     throw new Error('Failed to fetch NFT image');

--- a/src/utils/socialPicture/index.ts
+++ b/src/utils/socialPicture/index.ts
@@ -41,24 +41,20 @@ const makeImageLink = (imageUrl: string) => {
 
 export const getNFTSocialPicture = async (
   pictureOrUrl: string,
-): Promise<[string, string | null]> => {
+): Promise<{ base64: string; imageUrl: string; mimeType: string | null }> => {
   if (pictureOrUrl.startsWith('data:')) {
     const mimeType = pictureOrUrl.substring(
       pictureOrUrl.indexOf(':') + 1,
       pictureOrUrl.indexOf(';'),
     );
     const base64 = pictureOrUrl.substring(pictureOrUrl.indexOf('base64,') + 7);
-    return [base64, mimeType];
+    return { base64, imageUrl: '', mimeType };
   }
   const resp = await nodeFetch(makeImageLink(pictureOrUrl), { timeout: 5000 });
   if (!resp.ok) {
     throw new Error('Failed to fetch NFT image');
   }
-  const data = await resp.buffer();
-  const mimeType = resp.headers.get('Content-Type');
-  const base64 = data.toString('base64');
-
-  return [base64, mimeType];
+  return { base64: '', imageUrl: pictureOrUrl, mimeType: null };
 };
 
 const getFontSize = (name: string): number => {
@@ -73,7 +69,8 @@ const getFontSize = (name: string): number => {
 
 export const createSocialPictureImage = (
   domain: Domain,
-  data: string,
+  backgroundImageData: string,
+  backgroundImageUrl: string,
   mimeType: string | null,
   backgroundColor: string,
   raw = false,
@@ -85,7 +82,8 @@ export const createSocialPictureImage = (
   const fontSize = getFontSize(name);
   const svg = createSVGfromTemplate({
     background_color: backgroundColor,
-    background_image: data,
+    background_image_url: backgroundImageUrl,
+    background_image_data: backgroundImageData,
     domain: name,
     fontSize,
     mimeType: mimeType || undefined,

--- a/src/utils/socialPicture/svgTemplate.ts
+++ b/src/utils/socialPicture/svgTemplate.ts
@@ -1,6 +1,7 @@
 interface SvgFields {
   background_color: string;
-  background_image: string;
+  background_image_url?: string;
+  background_image_data: string;
   domain: string;
   fontSize: number;
   mimeType?: string;
@@ -11,7 +12,8 @@ const FontFamily =
 
 export default function createSocialPictureSvg({
   background_color,
-  background_image,
+  background_image_url,
+  background_image_data,
   domain,
   fontSize,
   mimeType,
@@ -25,7 +27,10 @@ export default function createSocialPictureSvg({
                 ? `<rect fill="${background_color}" width="300" height="300"/>`
                 : ''
             }
-            <image href="data:${mimeType};base64,${background_image}" width="300" height="300" />
+            <image href="${
+              background_image_url ||
+              `data:${mimeType};base64,${background_image_data}`
+            }" width="300" height="300" />
           </pattern>
           <filter id="shadowy">
             <feDiffuseLighting in="SourceGraphic" result="light"


### PR DESCRIPTION
2 Updates:

1. Checks if NFT PFP is actually owned by the domain's owner. This prevents domain owners from setting an NFT they don't own as their PFP.
2. Uses NFT image_url instead of image_data for background image. This could help with response times.