### PR TITLE
Fix env var parsing

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -41,6 +41,10 @@ if (requiredEnvNotSet.length !== 0) {
 
 const ZnsNetwork = process.env.ZNS_NETWORK || 'mainnet';
 
+function parseNumberFromEnv(envVar: string | undefined, defaultVal: number) {
+  return !isNaN(Number(envVar)) ? Number(envVar) : defaultVal;
+}
+
 export type EthUpdaterConfig = {
   CNS_REGISTRY_EVENTS_STARTING_BLOCK: number;
   UNS_REGISTRY_EVENTS_STARTING_BLOCK: number;
@@ -62,50 +66,83 @@ export const env = {
       ? process.env.RESOLUTION_RUNNING_MODE.split(',')
       : ['MIGRATIONS', 'API', 'ETH_WORKER', 'MATIC_WORKER', 'ZIL_WORKER'],
     ETHEREUM: {
-      CNS_REGISTRY_EVENTS_STARTING_BLOCK: Number(
-        process.env.CNS_REGISTRY_EVENTS_STARTING_BLOCK || 9080000,
+      CNS_REGISTRY_EVENTS_STARTING_BLOCK: parseNumberFromEnv(
+        process.env.CNS_REGISTRY_EVENTS_STARTING_BLOCK,
+        9080000,
       ),
-      UNS_REGISTRY_EVENTS_STARTING_BLOCK: Number(
-        process.env.UNS_REGISTRY_EVENTS_STARTING_BLOCK || 12779230,
+      UNS_REGISTRY_EVENTS_STARTING_BLOCK: parseNumberFromEnv(
+        process.env.UNS_REGISTRY_EVENTS_STARTING_BLOCK,
+        12779230,
       ),
       JSON_RPC_API_URL: process.env.ETHEREUM_JSON_RPC_API_URL,
-      NETWORK_ID: Number(process.env.ETHEREUM_NETWORK_ID || 1),
-      CONFIRMATION_BLOCKS: Number(
-        process.env.ETHEREUM_CONFIRMATION_BLOCKS || 20,
+      NETWORK_ID: parseNumberFromEnv(process.env.ETHEREUM_NETWORK_ID, 1),
+      CONFIRMATION_BLOCKS: parseNumberFromEnv(
+        process.env.ETHEREUM_CONFIRMATION_BLOCKS,
+        20,
       ),
-      BLOCK_FETCH_LIMIT: Number(process.env.ETHEREUM_BLOCK_FETCH_LIMIT || 500),
-      CNS_RESOLVER_ADVANCED_EVENTS_STARTING_BLOCK: Number(
-        process.env.CNS_RESOLVER_ADVANCED_EVENTS_STARTING_BLOCK || 9080000,
+      BLOCK_FETCH_LIMIT: parseNumberFromEnv(
+        process.env.ETHEREUM_BLOCK_FETCH_LIMIT,
+        500,
       ),
-      RECORDS_PER_PAGE: Number(process.env.ETHEREUM_RECORDS_PER_PAGE || 100),
-      FETCH_INTERVAL: Number(process.env.ETHEREUM_FETCH_INTERVAL || 5000),
-      MAX_REORG_SIZE: Number(process.env.ETHEREUM_MAX_REORG_SIZE || 200),
-      ACCEPTABLE_DELAY_IN_BLOCKS: Number(
-        process.env.ETHEREUM_ACCEPTABLE_DELAY_IN_BLOCKS || 100,
+      CNS_RESOLVER_ADVANCED_EVENTS_STARTING_BLOCK: parseNumberFromEnv(
+        process.env.CNS_RESOLVER_ADVANCED_EVENTS_STARTING_BLOCK,
+        9080000,
+      ),
+      RECORDS_PER_PAGE: parseNumberFromEnv(
+        process.env.ETHEREUM_RECORDS_PER_PAGE,
+        100,
+      ),
+      FETCH_INTERVAL: parseNumberFromEnv(
+        process.env.ETHEREUM_FETCH_INTERVAL,
+        5000,
+      ),
+      MAX_REORG_SIZE: parseNumberFromEnv(
+        process.env.ETHEREUM_MAX_REORG_SIZE,
+        200,
+      ),
+      ACCEPTABLE_DELAY_IN_BLOCKS: parseNumberFromEnv(
+        process.env.ETHEREUM_ACCEPTABLE_DELAY_IN_BLOCKS,
+        100,
       ),
     } as EthUpdaterConfig,
     POLYGON: {
-      CNS_REGISTRY_EVENTS_STARTING_BLOCK: Number(
-        process.env.POLYGON_CNS_REGISTRY_EVENTS_STARTING_BLOCK || 19345077,
+      CNS_REGISTRY_EVENTS_STARTING_BLOCK: parseNumberFromEnv(
+        process.env.POLYGON_CNS_REGISTRY_EVENTS_STARTING_BLOCK,
+        19345077,
       ),
-      UNS_REGISTRY_EVENTS_STARTING_BLOCK: Number(
-        process.env.POLYGON_UNS_REGISTRY_EVENTS_STARTING_BLOCK || 19345077,
+      UNS_REGISTRY_EVENTS_STARTING_BLOCK: parseNumberFromEnv(
+        process.env.POLYGON_UNS_REGISTRY_EVENTS_STARTING_BLOCK,
+        19345077,
       ),
       JSON_RPC_API_URL: process.env.POLYGON_JSON_RPC_API_URL,
-      NETWORK_ID: Number(process.env.POLYGON_NETWORK_ID || 137),
-      CONFIRMATION_BLOCKS: Number(
-        process.env.POLYGON_CONFIRMATION_BLOCKS || 20,
+      NETWORK_ID: parseNumberFromEnv(process.env.POLYGON_NETWORK_ID, 137),
+      CONFIRMATION_BLOCKS: parseNumberFromEnv(
+        process.env.POLYGON_CONFIRMATION_BLOCKS,
+        20,
       ),
-      BLOCK_FETCH_LIMIT: Number(process.env.POLYGON_BLOCK_FETCH_LIMIT || 500),
-      CNS_RESOLVER_ADVANCED_EVENTS_STARTING_BLOCK: Number(
-        process.env.POLYGON_CNS_RESOLVER_ADVANCED_EVENTS_STARTING_BLOCK ||
-          19345077,
+      BLOCK_FETCH_LIMIT: parseNumberFromEnv(
+        process.env.POLYGON_BLOCK_FETCH_LIMIT,
+        500,
       ),
-      RECORDS_PER_PAGE: Number(process.env.POLYGON_RECORDS_PER_PAGE || 100),
-      FETCH_INTERVAL: Number(process.env.POLYGON_FETCH_INTERVAL || 5000),
-      MAX_REORG_SIZE: Number(process.env.POLYGON_MAX_REORG_SIZE || 200),
-      ACCEPTABLE_DELAY_IN_BLOCKS: Number(
-        process.env.POLYGON_ACCEPTABLE_DELAY_IN_BLOCKS || 100,
+      CNS_RESOLVER_ADVANCED_EVENTS_STARTING_BLOCK: parseNumberFromEnv(
+        process.env.POLYGON_CNS_RESOLVER_ADVANCED_EVENTS_STARTING_BLOCK,
+        19345077,
+      ),
+      RECORDS_PER_PAGE: parseNumberFromEnv(
+        process.env.POLYGON_RECORDS_PER_PAGE,
+        100,
+      ),
+      FETCH_INTERVAL: parseNumberFromEnv(
+        process.env.POLYGON_FETCH_INTERVAL,
+        5000,
+      ),
+      MAX_REORG_SIZE: parseNumberFromEnv(
+        process.env.POLYGON_MAX_REORG_SIZE,
+        200,
+      ),
+      ACCEPTABLE_DELAY_IN_BLOCKS: parseNumberFromEnv(
+        process.env.POLYGON_ACCEPTABLE_DELAY_IN_BLOCKS,
+        100,
       ),
     } as EthUpdaterConfig,
     ZILLIQA: {
@@ -121,11 +158,15 @@ export const env = {
           : 'https://dev-api.zilliqa.com/',
       VIEWBLOCK_API_KEY: process.env.VIEWBLOCK_API_KEY,
       VIEWBLOCK_API_URL: 'https://api.viewblock.io/v1/zilliqa',
-      FETCH_INTERVAL: Number(process.env.ZNS_FETCH_INTERVAL || 5000),
-      ACCEPTABLE_DELAY_IN_BLOCKS: Number(
-        process.env.ZILLIQA_ACCEPTABLE_DELAY_IN_BLOCKS || 200,
+      FETCH_INTERVAL: parseNumberFromEnv(process.env.ZNS_FETCH_INTERVAL, 5000),
+      ACCEPTABLE_DELAY_IN_BLOCKS: parseNumberFromEnv(
+        process.env.ZILLIQA_ACCEPTABLE_DELAY_IN_BLOCKS,
+        200,
       ),
-      CONFIRMATION_BLOCKS: Number(process.env.ZILLIQA_CONFIRMATION_BLOCKS || 0),
+      CONFIRMATION_BLOCKS: parseNumberFromEnv(
+        process.env.ZILLIQA_CONFIRMATION_BLOCKS,
+        0,
+      ),
     },
     ERC721_METADATA: {
       GOOGLE_CLOUD_STORAGE_BASE_URL:
@@ -152,7 +193,7 @@ export const env = {
           rejectUnauthorized: false,
         }
       : undefined,
-    port: Number(process.env.RESOLUTION_POSTGRES_PORT || 5432),
+    port: parseNumberFromEnv(process.env.RESOLUTION_POSTGRES_PORT, 5432),
     entities: [
       path.join(__dirname, './models/index.ts'),
       path.join(__dirname, './models/index.js'),
@@ -162,11 +203,18 @@ export const env = {
       path.join(__dirname, './database/migrations/*.js'),
     ] as string[],
     SNAPSHOT: {
-      cnsEventsCount: Number(process.env.SNAPSHOT_CNS_EVENTS_COUNT || 966679),
-      znsTransactionsCount: Number(
-        process.env.SNAPSHOT_ZNS_TRANSACTIONS_COUNT || 95203,
+      cnsEventsCount: parseNumberFromEnv(
+        process.env.SNAPSHOT_CNS_EVENTS_COUNT,
+        966679,
       ),
-      domainsCount: Number(process.env.SNAPSHOT_DOMAINS_COUNT || 269650),
+      znsTransactionsCount: parseNumberFromEnv(
+        process.env.SNAPSHOT_ZNS_TRANSACTIONS_COUNT,
+        95203,
+      ),
+      domainsCount: parseNumberFromEnv(
+        process.env.SNAPSHOT_DOMAINS_COUNT,
+        269650,
+      ),
     },
   },
   MORALIS: {


### PR DESCRIPTION
## Background

It seems like we have some problems with parsing env vars. Empty values are passed from deployment scripts if the value is not defined. In that case the resulting number is `NaN` which may cause issues for workers and the service in general.

For example, the staging matic worker is failing to sync because `POLYGON_BLOCK_FETCH_LIMIT` is not defined.

## Changes

This PR adds an additional `isNaN` check for numeric env variables to prevent invalid values from being saved to configs.