### PR TITLE
Possible svg rendering fix

### DIFF
--- a/src/utils/generalImage.ts
+++ b/src/utils/generalImage.ts
@@ -9,12 +9,12 @@ export function DefaultImageData(args: {
   tld: string;
   fontSize: MetadataImageFontSize;
 }): string {
-  return `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="250px" height="250px" viewBox="0 0 250 250" version="1.1" style="background-color:#4C47F7">
+  return `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="250px" height="250px" viewBox="0 0 250 250" version="1.1" fill="none">
   <!-- Generator: Sketch 61 (89581) - https://sketch.com -->
   <title>unstoppabledomains_dot_crypto-</title>
   <desc>Created with Sketch.</desc>
   <g id="unstoppabledomains" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-      <rect fill="#${BackgroundColor}" x="0" y="0" width="100%" height="100%"/>
+      <rect fill="#${BackgroundColor}" x="0" y="0" width="250" height="250"/>
       <g id="Group-6" transform="translate(70.000000, 154.000000)">
           <g id="Group" transform="translate(5.000000, 43.000000)">
           <rect x="${args.tld === 'blockchain' ? -26 : 0}" y="0" width="${


### PR DESCRIPTION
Some change that can possibly fix where our domains are not displaying properly in wallets like Trust and Coinbase.

Example of valid ENS image: https://metadata.ens.domains/mainnet/0x57f1887a8bf19b14fc0df6fd9b2acc9af147ea85/76161309123142072325363708320113514550290800716594317694044198374403004720591/image

Example of UD not displaying correctly:
<img width="437" alt="Screen Shot 2022-05-18 at 2 48 21 PM" src="https://user-images.githubusercontent.com/23408540/169161478-0b7d4ec5-137f-46d6-bf37-980bc66c4cea.png">


We should watch out for and check if this change won't negatively affect our current images like NFT PFP or image rendering elsewhere like on our website