### PR TITLE
[ECUX-291] fix: Fix .svg ending appearing in our metadata service and…

### DIFF
--- a/src/controllers/MetaDataController.ts
+++ b/src/controllers/MetaDataController.ts
@@ -632,7 +632,7 @@ export class MetaDataController {
     if (this.isDomainWithCustomImage(name)) {
       return '';
     }
-    const splittedName = name.split('.');
+    const splittedName = name.replace(/\.svg/g, '').split('.');
     const extension = splittedName.pop() || '';
     const label = splittedName.join('.');
 

--- a/src/utils/generalImage.ts
+++ b/src/utils/generalImage.ts
@@ -2,7 +2,7 @@ import { MetadataImageFontSize } from '../types/common';
 
 export const BackgroundColor = '4C47F7';
 export const FontFamily =
-  "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Ubuntu, 'Helvetica Neue', Oxygen, Cantarell, sans-serif";
+  'system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Ubuntu, Helvetica Neue, Oxygen, Cantarell, sans-serif';
 
 const smallFontSizeTlds = ['blockchain', 'unstoppable'];
 

--- a/src/utils/socialPicture/svgTemplate.ts
+++ b/src/utils/socialPicture/svgTemplate.ts
@@ -7,7 +7,7 @@ interface SvgFields {
 }
 
 const FontFamily =
-  "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Ubuntu, 'Helvetica Neue', Oxygen, Cantarell, sans-serif";
+  'system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Ubuntu, Helvetica Neue, Oxygen, Cantarell, sans-serif';
 
 export default function svgTemplate({
   background_color,


### PR DESCRIPTION
## Background
We currently generate the wrong domain image when there's a double '.svg' ending in the metadata URL.
![image](https://user-images.githubusercontent.com/87966933/175275514-00944e3a-8370-4bef-b263-b019f10b4dac.png)
Context: https://unstoppabledomains.slack.com/archives/C02P0QWAYG7/p1655972284319989

## Related Issue
https://linear.app/unstoppable-domains/issue/ECUX-291/fix-svg-ending-appearing-in-our-metadata-service-and-on-the-opensea

## Changes
- We're now removing the '.svg' when getting the domain label and ending

## Desktop & Mobile Screenshots
<img width="521" alt="unstoppabledomains_dot_crypto- 2022-06-23 12-12-50" src="https://user-images.githubusercontent.com/87966933/175275933-1436fa68-d815-4439-bea7-d3b624581b81.png">

