### PR TITLE
Add debug configuration for development.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:ci": "NODE_ENV=test nyc --reporter=text yarn test -- --bail --quiet",
     "build": "tsc",
     "start:dev": "dotenv -e ./local.dev.env -- ts-node src/index.ts",
+    "start:dev:debug": "dotenv -e ./local.dev.env -- nodemon --exec 'node --inspect --require ts-node/register ./src/index.ts'",
     "fix": "yarn prettier:fix && yarn eslint:fix",
     "lint": "yarn build:check && yarn prettier:check && yarn eslint:check",
     "build:check": "tsc --noEmit",


### PR DESCRIPTION
This change allows to attach debugger when developing locally.

<img width="1519" alt="Screen Shot 2022-07-06 at 7 43 58 PM" src="https://user-images.githubusercontent.com/742796/177611891-c1a5a271-0bc1-40de-ab63-73308136e2f9.png">


Debugger attaches on standart port 9229 by default.


If developing in VS Code need to add debug launch configuration to `launch.json`

```
{
  "version": "0.2.0",
  "configurations": [
    {
      "type": "node",
      "request": "attach",
      "name": "Attach to resolution service",
      "protocol": "inspector",
      "port": 9229,
      "restart": true,
      "localRoot": "${workspaceFolder}",
      "remoteRoot": "${workspaceFolder}"
    },
  ]
}

```
https://code.visualstudio.com/docs/editor/debugging

## Changes
- Added ```start:dev:debug``` launch configuration