### PR TITLE
Fix token ID matching

### DIFF
--- a/src/utils/domain.test.ts
+++ b/src/utils/domain.test.ts
@@ -1,0 +1,35 @@
+import { expect } from 'chai';
+import { normalizeDomainOrToken } from './domain';
+import { eip137Namehash } from './namehash';
+
+describe('utils/domain', () => {
+  describe('normalizeDomainOrToken', () => {
+    it('trims spaces and converts a domain name into an eip137 hash', () => {
+      const domainName = ' Heyo.crypto   ';
+      expect(normalizeDomainOrToken(domainName)).to.eq(
+        eip137Namehash(domainName.trim().toLowerCase()),
+      );
+    });
+
+    it('normalizes token ID', () => {
+      const tokenId =
+        '6304531997610998161237844647282663196661123000121147597890468333969432655810';
+      expect(normalizeDomainOrToken(tokenId)).to.eq(
+        eip137Namehash('uns-devtest-265f8f.wallet'),
+      );
+    });
+
+    it('normalizes node', () => {
+      const node =
+        '0x0df03d18a0a02673661da22d06f43801a986840e5812989139f0f7a2c41037c2';
+      expect(normalizeDomainOrToken(node)).to.eq(
+        eip137Namehash('uns-devtest-265f8f.wallet'),
+      );
+    });
+
+    it('does not normalize gibberish', () => {
+      const gibberish = '@@@@@@@@@@@';
+      expect(gibberish).to.eq(gibberish);
+    });
+  });
+});

--- a/src/utils/domain.ts
+++ b/src/utils/domain.ts
@@ -15,10 +15,7 @@ export const normalizeDomainOrToken = (domainOrToken: string): string => {
 
   if (domainName.includes('.')) {
     return eip137Namehash(domainName);
-  } else if (
-    domainName.startsWith('0x') &&
-    domainName.replace('0x', '').match(/^[a-fA-F0-9]+$/)
-  ) {
+  } else if (domainName.replace('0x', '').match(/^[a-fA-F0-9]+$/)) {
     return normalizeToken(domainName);
   }
 


### PR DESCRIPTION
Per a recent PR review there was a suggestion to add a check for `startsWith`, assuming we're matching ETH addresses.

The issue here is that we stopped matching token IDs. So we're returning back to a previous lose matching:
```js
/^[a-fA-F0-9]+$/.test('6304531997610998161237844647282663196661123000121147597890468333969432655810'); // true
```