### PR TITLE
Add test debugging configuration and REAME notes how to debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,33 @@ For checking coverage use `yarn test:coverage`.
 Unit/integration tests use a postgres database that is cleaned before each test.
 By default, the database name is `resolution_service_test`.
 
+### Debugging
+To debug the service the following command could be used:
+```
+yarn start:dev:debug
+```
+
+To debug the tests use:
+```
+yarn test:debug
+```
+
+If you are using [Visual Studio Code](https://docs.microsoft.com/en-us/visualstudio/debugger/attach-to-running-processes-with-the-visual-studio-debugger?view=vs-2022) to debug the code add this to `.vscode/launch.json` launch configuration:
+```
+  "configurations": [
+    ...,
+    {
+      "type": "node",
+      "request": "attach",
+      "name": "Attach to resolution service",
+      "protocol": "inspector",
+      "port": 9229,
+      "restart": true,
+      "localRoot": "${workspaceFolder}",
+      "remoteRoot": "${workspaceFolder}"
+    },
+```
+
 ### Service architecture
 
 ![Architecture chart](doc/ResolutionService.png)

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "scripts": {
     "test": "dotenv -e local.test.env -- mocha --exit",
+    "test:debug": "dotenv -e local.test.env -- mocha --inspect-brk --exit",
     "test:coverage": "NODE_ENV=test nyc --reporter=text yarn test",
     "test:ci": "NODE_ENV=test nyc --reporter=text yarn test -- --bail --quiet",
     "build": "tsc",


### PR DESCRIPTION
It would be great to add test debugging configuration to the service.
I've added new launch conf to `package.json` and updated REAME notes how to debug,

now it's super easy to debug tests in my VS code IDE:
<img width="1674" alt="Screen Shot 2022-08-18 at 10 04 00 AM" src="https://user-images.githubusercontent.com/742796/185343614-27fe5ec3-e07e-4a56-b906-6bdd2590068e.png">

