### PR TITLE
Caching by token URI and domain name for PFP images with overlay

### DIFF
--- a/src/controllers/MetaDataController.ts
+++ b/src/controllers/MetaDataController.ts
@@ -26,7 +26,7 @@ import {
 import punycode from 'punycode';
 import { getDomainResolution } from '../services/Resolution';
 import { PremiumDomains, CustomImageDomains } from '../utils/domainCategories';
-import { DomainsResolution } from '../models';
+import { Domain, DomainsResolution } from '../models';
 import { OpenSeaPort, Network } from 'opensea-js';
 import { EthereumProvider } from '../workers/EthereumProvider';
 import { findDomainByNameOrToken } from '../utils/domain';
@@ -276,9 +276,11 @@ export class MetaDataController {
       const socialPictureValue = resolution.resolution['social.picture.value'];
       const pfpImageFromCDN =
         socialPictureValue &&
-        (await getNftPfpImageFromCDN(
+        (await getOrCacheNowPfpNFT(
           socialPictureValue,
-          withOverlay ? domain.name : undefined,
+          domain,
+          resolution,
+          withOverlay,
         ));
 
       return {
@@ -317,9 +319,11 @@ export class MetaDataController {
       const socialPictureValue = resolution.resolution['social.picture.value'];
       const pfpImageFromCDN =
         socialPictureValue &&
-        (await getNftPfpImageFromCDN(
+        (await getOrCacheNowPfpNFT(
           socialPictureValue,
-          withOverlay ? domain.name : undefined,
+          domain,
+          resolution,
+          withOverlay,
         ));
 
       return (
@@ -640,4 +644,27 @@ export async function fetchTokenMetadata(
     image = fetchedMetadata?.image;
   }
   return { fetchedMetadata, image }; // TODO: get rid of socialPicture param
+}
+
+async function getOrCacheNowPfpNFT(
+  socialPicture: string,
+  domain: Domain,
+  resolution: DomainsResolution,
+  withOverlay: boolean,
+) {
+  const cachedPfpNFT = await getNftPfpImageFromCDN(
+    socialPicture,
+    withOverlay ? domain.name : undefined,
+  );
+  if (!cachedPfpNFT) {
+    await cacheSocialPictureInCDN(socialPicture, domain, resolution);
+    // This is not optimal, should return image instead of 2nd call
+    // TODO: improve PFP NFT fetching after caching in CDN
+    const trulyCachedPFPNFT = await getNftPfpImageFromCDN(
+      socialPicture,
+      withOverlay ? domain.name : undefined,
+    );
+    return trulyCachedPFPNFT;
+  }
+  return cachedPfpNFT;
 }

--- a/src/controllers/MetaDataController.ts
+++ b/src/controllers/MetaDataController.ts
@@ -203,7 +203,10 @@ export class MetaDataController {
     const socialPictureValue = resolution.resolution['social.picture.value'];
     const socialPicture =
       socialPictureValue &&
-      (await getNftPfpImageFromCDN(socialPictureValue, withOverlay));
+      (await getNftPfpImageFromCDN(
+        socialPictureValue,
+        withOverlay ? domain.name : undefined,
+      ));
 
     // we consider that NFT picture is verified if the picture is present in our CDN cache.
     // It means it was verified before caching.
@@ -273,7 +276,10 @@ export class MetaDataController {
       const socialPictureValue = resolution.resolution['social.picture.value'];
       const pfpImageFromCDN =
         socialPictureValue &&
-        (await getNftPfpImageFromCDN(socialPictureValue, withOverlay));
+        (await getNftPfpImageFromCDN(
+          socialPictureValue,
+          withOverlay ? domain.name : undefined,
+        ));
 
       return {
         image_data:
@@ -311,7 +317,10 @@ export class MetaDataController {
       const socialPictureValue = resolution.resolution['social.picture.value'];
       const pfpImageFromCDN =
         socialPictureValue &&
-        (await getNftPfpImageFromCDN(socialPictureValue, withOverlay));
+        (await getNftPfpImageFromCDN(
+          socialPictureValue,
+          withOverlay ? domain.name : undefined,
+        ));
 
       return (
         pfpImageFromCDN ||

--- a/src/utils/socialPicture/index.ts
+++ b/src/utils/socialPicture/index.ts
@@ -185,12 +185,11 @@ export const cacheSocialPictureInCDN = async (
         files.push({ fname: fileNameWithOverlay, data: withOverlayImageData });
       }
 
-      //TODO: this actually doesn't wait for uploading to finish. Re-do so we wait
-      await Promise.all(
-        files.map(({ fname, data }) => {
-          uploadSVG(fname, data);
-        }),
-      );
+      // @TODO: this actually doesn't wait for uploading to finish. Re-do so we wait
+      // temporarity replaced Promise.all() with seqential execution instead of parallel
+      for (const file of files) {
+        await uploadSVG(file.fname, file.data);
+      }
     } else {
       logger.error(
         `Failed to generate image data for the domain: ${domain}, token URI: ${socialPic}`,

--- a/src/utils/socialPicture/index.ts
+++ b/src/utils/socialPicture/index.ts
@@ -185,6 +185,7 @@ export const cacheSocialPictureInCDN = async (
         files.push({ fname: fileNameWithOverlay, data: withOverlayImageData });
       }
 
+      //TODO: this actually doesn't wait for uploading to finish. Re-do so we wait
       await Promise.all(
         files.map(({ fname, data }) => {
           uploadSVG(fname, data);


### PR DESCRIPTION
Currently in some domains PFP NFT with overlays, the label on the picture doesn't match the domain name (see the [discussion in Slack](https://unstoppabledomains.slack.com/archives/C035FLNDVC4/p1660670875717679?thread_ts=1660625181.348839&cid=C035FLNDVC4)).
This happens because we currently cache images with overlay only one time, without associating it him domain names, so outdated names are displayed on the images when user assign old PFP NFT to a new domain.

<img width="713" alt="slack___threads___unstoppable_domains___1_new_item_2022-08-16_23-45-14" src="https://user-images.githubusercontent.com/742796/185364398-aa960d7a-aa58-4bd4-b093-7b0f68d21f12.png">

I've implemented images caching based on both token URI and domain name.

Subtasks:
- [ ] convert all SVG to PNG (with 1024x1024 res)
- [ ] use redirect instead of reading file in memory from CDN
- [ ] perform data migration
 