### PR TITLE
Don't ignore optional dependencies in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,6 @@ ADD . ./
 RUN yarn build
 
 # Cleanup development packages
-RUN yarn install --prefer-offline --frozen-lockfile --production --unsafe-perm --ignore-optional
+RUN yarn install --prefer-offline --frozen-lockfile --production --unsafe-perm
 
 ENTRYPOINT ["node", "build/src/index.js"]


### PR DESCRIPTION
Ignoring optional dependencies causes the build process to avoid installing platform-specific dependencies.

This should fix the resvg lib integration.