### PR TITLE
Remove IPFS Content attribute

### DIFF
--- a/src/controllers/MetaDataController.test.ts
+++ b/src/controllers/MetaDataController.test.ts
@@ -68,7 +68,7 @@ describe('MetaDataController', () => {
       expect(resWithName.image).eq(
         'https://metadata.unstoppabledomains.com/image-src/testdomain.crypto.svg',
       );
-      expect(resWithName.attributes.length).eq(5);
+      expect(resWithName.attributes.length).eq(4);
       const correctAttributes = [
         { trait_type: 'domain', value: 'testdomain.crypto' },
         { trait_type: 'level', value: 2 },

--- a/src/controllers/MetaDataController.test.ts
+++ b/src/controllers/MetaDataController.test.ts
@@ -73,10 +73,6 @@ describe('MetaDataController', () => {
         { trait_type: 'domain', value: 'testdomain.crypto' },
         { trait_type: 'level', value: 2 },
         { trait_type: 'length', value: 10 },
-        {
-          trait_type: 'IPFS Content',
-          value: 'QmdyBw5oTgCtTLQ18PbDvPL8iaLoEPhSyzD91q9XmgmAjb',
-        },
         { trait_type: 'type', value: 'standard' },
       ];
       expect(resWithName.attributes).to.have.deep.members(correctAttributes);
@@ -388,12 +384,6 @@ describe('MetaDataController', () => {
             value: 'standard',
           },
         ];
-        if (domain.label === 'india') {
-          correctAttributes.push({
-            trait_type: 'IPFS Content',
-            value: 'QmQq1ydvSmzrZPkr4CJJtetNSb9eSBucqQ4QoNmiRdMHzM',
-          });
-        }
         expect(response.attributes.length).to.eq(correctAttributes.length);
         expect(response.attributes).to.have.deep.members(correctAttributes);
       }
@@ -421,16 +411,6 @@ describe('MetaDataController', () => {
         .send()
         .then((r) => r.body);
 
-      expect(dwebHashResponse.attributes).to.deep.contain({
-        trait_type: 'IPFS Content',
-        value: 'ipfs hash content',
-      });
-
-      expect(htmlValueResponse.attributes).to.deep.contain({
-        trait_type: 'IPFS Content',
-        value: 'ipfs hash content',
-      });
-
       expect(dwebHashResponse.properties).to.deep.equals({
         records: { 'dweb.ipfs.hash': 'ipfs hash content' },
       });
@@ -447,10 +427,6 @@ describe('MetaDataController', () => {
         .get(`/metadata/${domain.name}`)
         .send()
         .then((r) => r.body);
-      expect(response.attributes).to.deep.contain({
-        trait_type: 'IPFS Content',
-        value: 'correct',
-      });
       expect(response.properties).to.deep.eq({
         records: {
           'dweb.ipfs.hash': 'correct',

--- a/src/controllers/MetaDataController.ts
+++ b/src/controllers/MetaDataController.ts
@@ -217,9 +217,6 @@ export class MetaDataController {
       resolution.resolution,
     );
     const domainAttributes = this.getDomainAttributes(domain.name, {
-      ipfsContent:
-        resolution.resolution['dweb.ipfs.hash'] ||
-        resolution.resolution['ipfs.html.value'],
       verifiedNftPicture: isSocialPictureVerified,
     });
 
@@ -403,7 +400,6 @@ export class MetaDataController {
   private getDomainAttributes(
     name: string,
     meta?: {
-      ipfsContent?: string;
       verifiedNftPicture?: boolean;
     },
   ): OpenSeaMetadataAttribute[] {
@@ -425,7 +421,6 @@ export class MetaDataController {
   private getBasicDomainAttributes(
     name: string,
     meta?: {
-      ipfsContent?: string;
       verifiedNftPicture?: boolean;
     },
   ): OpenSeaMetadataAttribute[] {

--- a/src/controllers/MetaDataController.ts
+++ b/src/controllers/MetaDataController.ts
@@ -444,9 +444,6 @@ export class MetaDataController {
       },
     ];
 
-    if (meta?.ipfsContent) {
-      attributes.push({ trait_type: 'IPFS Content', value: meta?.ipfsContent });
-    }
     if (meta?.verifiedNftPicture) {
       attributes.push({
         trait_type: 'picture',


### PR DESCRIPTION
Trying to simplify the attributes for our metadata endpoint. I don't think the IPFS trait is useful at all. We've had this trait for years and we should've never had it in the first place