### PR TITLE
Feature/dt 907/redirect root to swagger docs

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -14,6 +14,8 @@ import Bugsnag from '@bugsnag/js';
 import BugsnagPluginExpress from '@bugsnag/plugin-express';
 import { env } from './env';
 import ErrorHandler from './errors/ErrorHandler';
+import { RoutingControllersOptions } from 'routing-controllers';
+import * as oa from 'openapi3-ts';
 
 const enabledControllers = [];
 
@@ -59,21 +61,36 @@ if (env.APPLICATION.BUGSNAG_API_KEY) {
 const schemas = validationMetadatasToSchemas({
   refPointerPrefix: '#/components/schemas/',
 });
+
+const description =
+  'The Resolution Service provides an API for getting domain data and metadata regardless \
+of the blockchain in which the domain is stored. The service caches blockchain events in a database for easy \
+retrieval without accessing any blockchain APIs. With the Resolution Service API, you can quickly build \
+applications directly communicating with the blockchain to get UD domain data with a single API request.';
+
 const storage = getMetadataArgsStorage();
-const swaggerSpec = routingControllersToSpec(
-  storage,
-  {},
-  {
-    components: {
-      schemas,
-      securitySchemes: {
-        apiKeyAuth: {
-          scheme: 'bearer',
-          type: 'http',
-        },
+const routingControllerOptions: RoutingControllersOptions = {};
+const additionalProperties: Partial<oa.OpenAPIObject> = {
+  info: {
+    title: 'Resolution Service',
+    description: description,
+    version: '1.0.0',
+  },
+  components: {
+    schemas,
+    securitySchemes: {
+      apiKeyAuth: {
+        scheme: 'bearer',
+        type: 'http',
       },
     },
   },
+};
+
+const swaggerSpec = routingControllersToSpec(
+  storage,
+  routingControllerOptions,
+  additionalProperties,
 );
 
 // There's no way to set a custom attribute for a specific parameter in routing-controllers-openapi

--- a/src/controllers/StatusController.test.ts
+++ b/src/controllers/StatusController.test.ts
@@ -37,6 +37,14 @@ describe('StatusController', () => {
     sinonSandbox.restore();
   });
 
+  it('should redirect user', async () => {
+    const res = await supertest(api)
+      .get('/')
+      .send()
+      .expect(302)
+      .expect('Location', '/api-docs');
+  });
+
   it('should return appropriate block counts', async () => {
     const expectedStatus = {
       blockchain: {

--- a/src/controllers/StatusController.ts
+++ b/src/controllers/StatusController.ts
@@ -1,4 +1,4 @@
-import { Get, JsonController } from 'routing-controllers';
+import { Get, JsonController, Redirect } from 'routing-controllers';
 import 'reflect-metadata';
 import { ResponseSchema } from 'routing-controllers-openapi';
 import { IsBoolean, IsNumber, ValidateNested } from 'class-validator';
@@ -72,6 +72,12 @@ export class StatusController {
       status.latestNetworkBlock - status.latestMirroredBlock <=
       status.acceptableDelayInBlocks + config.CONFIRMATION_BLOCKS;
     return status;
+  }
+
+  @Get('/')
+  @Redirect('/api-docs')
+  getRoot() {
+    // Redirects to /api-docs
   }
 
   @Get('/status')


### PR DESCRIPTION
Completes https://linear.app/unstoppable-domains/issue/DT-907/redirect-resolveudcom-to-resolveudcomapi-docs

This redirects from / to /api-docs. It adds a description and title to the /api-docs page to indicate its intent.