### PR TITLE
Add support for sub-domains inside domain metadata endpoint

### DIFF
--- a/src/controllers/MetaDataController.test.ts
+++ b/src/controllers/MetaDataController.test.ts
@@ -109,6 +109,51 @@ describe('MetaDataController', () => {
       expect(resWithName.background_color).eq(BackgroundColor);
     });
 
+    it('should work with a subdomain', async () => {
+      const name = 'sub.domain.crypto';
+      const node = eip137Namehash(name);
+      const { domain } = await DomainTestHelper.createTestDomain({
+        name,
+        node,
+      });
+      const resWithName = await supertest(api)
+        .get(`/metadata/${domain.name}`)
+        .send()
+        .then((r) => r.body);
+
+      const resWithToken = await supertest(api)
+        .get(`/metadata/${domain.node}`)
+        .send()
+        .then((r) => r.body);
+
+      expect(resWithName).to.be.deep.equal(resWithToken);
+      expect(resWithName.name).eq(domain.name);
+      expect(resWithName.description).eq(
+        'A CNS or UNS blockchain domain. Use it to resolve your cryptocurrency addresses and decentralized websites.',
+      );
+      expect(resWithName.external_url).eq(
+        'https://unstoppabledomains.com/search?searchTerm=sub.domain.crypto',
+      );
+      expect(resWithName.image).eq(
+        'https://metadata.unstoppabledomains.com/image-src/sub.domain.crypto.svg',
+      );
+      const correctAttributes = [
+        { trait_type: DomainAttributeTrait.Level, value: 3 },
+        { trait_type: DomainAttributeTrait.Ending, value: 'crypto' },
+        { trait_type: DomainAttributeTrait.Length, value: 10 },
+        {
+          trait_type: DomainAttributeTrait.Type,
+          value: AttributeType.Standard,
+        },
+        {
+          trait_type: DomainAttributeTrait.AttributeCharacterSet,
+          value: AttributeCharacterSet.Letter,
+        },
+      ];
+      expect(resWithName.attributes.length).eq(correctAttributes.length);
+      expect(resWithName.attributes).to.have.deep.members(correctAttributes);
+    });
+
     it.skip('should render a deprecated image placeholder for .coin domain', async () => {
       const name = 'deprecated.coin';
       const node = eip137Namehash(name);

--- a/src/controllers/MetaDataController.ts
+++ b/src/controllers/MetaDataController.ts
@@ -392,7 +392,7 @@ export class MetaDataController {
       return "This is the only TLD on the Unstoppable registry. It's not owned by anyone.".concat(
         ipfsDescriptionPart,
       );
-    } else if (levels === 2) {
+    } else if (levels === 2 || levels === 3) {
       const description = belongsToTld(name, UnstoppableDomainTlds.Coin)
         ? '.coin domains are no longer supported by Unstoppable Domains. As a result, records of such domains cannot be updated. Learn more at our blog: https://unstoppabledomains.com/blog/coin. '
         : 'A CNS or UNS blockchain domain. Use it to resolve your cryptocurrency addresses and decentralized websites.';


### PR DESCRIPTION
## Background / Changes

Add support for subdomains metadata into domain metadata endpoint. Example of a subdomain: lisa.seacat.x.

## Code Review

This Pull Request was thoroughly reviewed and meets all Code Review Standards pertaining to:

- [x] **Implementation** - satisfied acceptance criteria
- [x] **Communication** - notified engineers/stakeholders about impactful changes
- [ ] **Error handling** - handled, logged & alerted on errors
- [ ] **Documentation** - wrote readable code & commits, documented unintuitive code
- [x] **Testing** - unit & E2E test coverage, tested in staging, DB migrations backwards compatible
- [ ] **Security** - sanitized inputs, vetted dependencies, validated/secured API requests, no committed secrets
- [ ] **Performance** - optimized expensive algorithms & database queries

Please select all **applied** standards relevant to this PR.
## Confirmation

- [x] **Assignee Confirmation** - I (the author) have filled out the template above
- [ ] **Reviewer Confirmation** - I (a/the reviewer) confirm 1) the author has filled out the template and checked the box that says **Assignee Confirmation** 2) I reviewed the code and selected all applicable items in the code review section.
