### PR TITLE
Add subdomains attribute type

### DIFF
--- a/src/controllers/MetaDataController.test.ts
+++ b/src/controllers/MetaDataController.test.ts
@@ -89,7 +89,7 @@ describe('MetaDataController', () => {
         { trait_type: DomainAttributeTrait.Length, value: 10 },
         {
           trait_type: DomainAttributeTrait.Type,
-          value: AttributeType.Standard,
+          value: AttributeType.Clean,
         },
         {
           trait_type: DomainAttributeTrait.AttributeCharacterSet,
@@ -198,7 +198,7 @@ describe('MetaDataController', () => {
         { trait_type: DomainAttributeTrait.Length, value: 10 },
         {
           trait_type: DomainAttributeTrait.Type,
-          value: AttributeType.Standard,
+          value: AttributeType.Clean,
         },
         {
           trait_type: DomainAttributeTrait.AttributeCharacterSet,
@@ -366,7 +366,7 @@ describe('MetaDataController', () => {
           { trait_type: DomainAttributeTrait.Length, value: 7 },
           {
             trait_type: DomainAttributeTrait.Type,
-            value: AttributeType.Standard,
+            value: AttributeType.Clean,
           },
           {
             trait_type: DomainAttributeTrait.AttributeCharacterSet,
@@ -418,7 +418,7 @@ describe('MetaDataController', () => {
           { trait_type: DomainAttributeTrait.Length, value: uns.label.length },
           {
             trait_type: DomainAttributeTrait.Type,
-            value: AttributeType.Standard,
+            value: AttributeType.Clean,
           },
           {
             trait_type: DomainAttributeTrait.AttributeCharacterSet,
@@ -503,7 +503,7 @@ describe('MetaDataController', () => {
           },
           {
             trait_type: DomainAttributeTrait.Type,
-            value: AttributeType.Standard,
+            value: AttributeType.Clean,
           },
           {
             trait_type: DomainAttributeTrait.AttributeCharacterSet,

--- a/src/controllers/MetaDataController.test.ts
+++ b/src/controllers/MetaDataController.test.ts
@@ -87,9 +87,10 @@ describe('MetaDataController', () => {
         { trait_type: DomainAttributeTrait.Level, value: 2 },
         { trait_type: DomainAttributeTrait.Ending, value: 'crypto' },
         { trait_type: DomainAttributeTrait.Length, value: 10 },
+        { trait_type: DomainAttributeTrait.Subdomains, value: 0 },
         {
           trait_type: DomainAttributeTrait.Type,
-          value: AttributeType.Clean,
+          value: AttributeType.Standard,
         },
         {
           trait_type: DomainAttributeTrait.AttributeCharacterSet,
@@ -196,9 +197,10 @@ describe('MetaDataController', () => {
           value: UnstoppableDomainTlds.Coin,
         },
         { trait_type: DomainAttributeTrait.Length, value: 10 },
+        { trait_type: DomainAttributeTrait.Subdomains, value: 0 },
         {
           trait_type: DomainAttributeTrait.Type,
-          value: AttributeType.Clean,
+          value: AttributeType.Standard,
         },
         {
           trait_type: DomainAttributeTrait.AttributeCharacterSet,
@@ -364,9 +366,10 @@ describe('MetaDataController', () => {
           { trait_type: DomainAttributeTrait.Ending, value: 'crypto' },
           { trait_type: DomainAttributeTrait.Level, value: 2 },
           { trait_type: DomainAttributeTrait.Length, value: 7 },
+          { trait_type: DomainAttributeTrait.Subdomains, value: 0 },
           {
             trait_type: DomainAttributeTrait.Type,
-            value: AttributeType.Clean,
+            value: AttributeType.Standard,
           },
           {
             trait_type: DomainAttributeTrait.AttributeCharacterSet,
@@ -416,9 +419,10 @@ describe('MetaDataController', () => {
           { trait_type: DomainAttributeTrait.Ending, value: 'wallet' },
           { trait_type: DomainAttributeTrait.Level, value: 2 },
           { trait_type: DomainAttributeTrait.Length, value: uns.label.length },
+          { trait_type: DomainAttributeTrait.Subdomains, value: 0 },
           {
             trait_type: DomainAttributeTrait.Type,
-            value: AttributeType.Clean,
+            value: AttributeType.Standard,
           },
           {
             trait_type: DomainAttributeTrait.AttributeCharacterSet,
@@ -501,9 +505,10 @@ describe('MetaDataController', () => {
             trait_type: DomainAttributeTrait.Length,
             value: domain.label.length,
           },
+          { trait_type: DomainAttributeTrait.Subdomains, value: 0 },
           {
             trait_type: DomainAttributeTrait.Type,
-            value: AttributeType.Clean,
+            value: AttributeType.Standard,
           },
           {
             trait_type: DomainAttributeTrait.AttributeCharacterSet,

--- a/src/controllers/MetaDataController.ts
+++ b/src/controllers/MetaDataController.ts
@@ -444,8 +444,12 @@ export class MetaDataController {
         value: domain.label.length,
       },
       {
+        trait_type: DomainAttributeTrait.Subdomains,
+        value: await Domain.getSubdomainCountByParentName(domain.name),
+      },
+      {
         trait_type: DomainAttributeTrait.Type,
-        value: await getAttributeType(domain),
+        value: getAttributeType(domain),
       },
     ];
     const category = getAttributeCategory(domain);

--- a/src/controllers/MetaDataController.ts
+++ b/src/controllers/MetaDataController.ts
@@ -233,7 +233,7 @@ export class MetaDataController {
       domain,
       resolution.resolution,
     );
-    const DomainAttributeTrait = this.getAttributeType(domain, {
+    const DomainAttributeTrait = await this.getAttributeType(domain, {
       verifiedNftPicture: isSocialPictureVerified,
     });
     const imageUrl = this.generateDomainImageUrl(domain.name);
@@ -368,7 +368,9 @@ export class MetaDataController {
     const description = name
       ? this.getDomainDescription(new Domain({ name }), {})
       : null;
-    const attributes = name ? this.getAttributeType(new Domain({ name })) : [];
+    const attributes = name
+      ? await this.getAttributeType(new Domain({ name }))
+      : [];
     const image = name ? this.generateDomainImageUrl(name) : null;
     const external_url = name
       ? `https://unstoppabledomains.com/search?searchTerm=${name}`
@@ -422,12 +424,12 @@ export class MetaDataController {
     return '';
   }
 
-  private getAttributeType(
+  private async getAttributeType(
     domain: Domain,
     meta?: {
       verifiedNftPicture?: boolean;
     },
-  ): OpenSeaMetadataAttribute[] {
+  ): Promise<OpenSeaMetadataAttribute[]> {
     const attributes: OpenSeaMetadataAttribute[] = [
       {
         trait_type: DomainAttributeTrait.Ending,
@@ -443,7 +445,7 @@ export class MetaDataController {
       },
       {
         trait_type: DomainAttributeTrait.Type,
-        value: getAttributeType(domain),
+        value: await getAttributeType(domain),
       },
     ];
     const category = getAttributeCategory(domain);

--- a/src/models/Domain.test.ts
+++ b/src/models/Domain.test.ts
@@ -11,6 +11,7 @@ import nock from 'nock';
 import { nockConfigure } from '../mochaHooks';
 import { DomainTestHelper } from '../utils/testing/DomainTestHelper';
 import DomainsReverseResolution from './DomainsReverseResolution';
+import { eip137Namehash } from '../utils/namehash';
 
 describe('Domain', () => {
   describe('constructor()', () => {
@@ -243,6 +244,37 @@ describe('Domain', () => {
         '0xb72f443a17edf4a55f766cf3c83469e6f96494b16823a41a4acb25800f303103',
       );
       expect(fromDb?.parent?.name).to.equal('crypto');
+    });
+  });
+
+  describe('.getSubdomainCountByParentName()', () => {
+    it('should return subdomain count', async () => {
+      const { domain } = await DomainTestHelper.createTestDomain({
+        name: 'test.nft',
+        node: eip137Namehash('test.nft'),
+        ownerAddress: '0x8aaD44321A86b170879d7A244c1e8d360c99DdA8',
+        blockchain: Blockchain.ETH,
+        networkId: 1337,
+        registry: '0xd1e5b0ff1287aa9f9a268759062e4ab08b9dacbe',
+        resolver: '0xd1e5b0ff1287aa9f9a268759062e4ab08b9dacbe',
+      });
+      const { domain: subdomain } = await DomainTestHelper.createTestDomain({
+        name: 'sub.test.nft',
+        node: eip137Namehash('sub.test.nft'),
+        ownerAddress: '0x8aaD44321A86b170879d7A244c1e8d360c99DdA8',
+        blockchain: Blockchain.ETH,
+        networkId: 1337,
+        registry: '0xd1e5b0ff1287aa9f9a268759062e4ab08b9dacbe',
+        resolver: '0xd1e5b0ff1287aa9f9a268759062e4ab08b9dacbe',
+      });
+      subdomain.parent = domain;
+      await subdomain.save();
+      expect(
+        await Domain.getSubdomainCountByParentName(domain.name),
+      ).to.be.equal(1);
+      expect(
+        await Domain.getSubdomainCountByParentName(subdomain.name),
+      ).to.be.equal(0);
     });
   });
 

--- a/src/models/Domain.ts
+++ b/src/models/Domain.ts
@@ -112,6 +112,15 @@ export default class Domain extends Model {
     return this.reverseResolutions.length > 0;
   }
 
+  static async getChildrenCountByParentName(
+    name: string,
+    repository: Repository<Domain> = this.getRepository(),
+  ): Promise<number> {
+    return repository.count({
+      where: { parent: { name } },
+      relations: ['parent'],
+    });
+  }
   static async findAllByNodes(
     nodes: string[],
     repository: Repository<Domain> = this.getRepository(),

--- a/src/models/Domain.ts
+++ b/src/models/Domain.ts
@@ -118,6 +118,7 @@ export default class Domain extends Model {
   ): Promise<boolean> {
     const child = await repository.findOne({
       where: { parent: { name } },
+      relations: ['parent'],
     });
     return Boolean(child);
   }

--- a/src/models/Domain.ts
+++ b/src/models/Domain.ts
@@ -119,6 +119,7 @@ export default class Domain extends Model {
     const child = await repository.findOne({
       where: { parent: { name } },
       relations: ['parent'],
+      cache: true,
     });
     return Boolean(child);
   }

--- a/src/models/Domain.ts
+++ b/src/models/Domain.ts
@@ -112,15 +112,16 @@ export default class Domain extends Model {
     return this.reverseResolutions.length > 0;
   }
 
-  static async getChildrenCountByParentName(
+  static async isNameParentOfChild(
     name: string,
     repository: Repository<Domain> = this.getRepository(),
-  ): Promise<number> {
-    return repository.count({
+  ): Promise<boolean> {
+    const child = await repository.findOne({
       where: { parent: { name } },
-      relations: ['parent'],
     });
+    return Boolean(child);
   }
+
   static async findAllByNodes(
     nodes: string[],
     repository: Repository<Domain> = this.getRepository(),

--- a/src/models/Domain.ts
+++ b/src/models/Domain.ts
@@ -112,16 +112,15 @@ export default class Domain extends Model {
     return this.reverseResolutions.length > 0;
   }
 
-  static async isNameParentOfChild(
+  static async getSubdomainCountByParentName(
     name: string,
     repository: Repository<Domain> = this.getRepository(),
-  ): Promise<boolean> {
-    const child = await repository.findOne({
+  ): Promise<number> {
+    return repository.count({
       where: { parent: { name } },
       relations: ['parent'],
       cache: true,
     });
-    return Boolean(child);
   }
 
   static async findAllByNodes(

--- a/src/utils/metadata/index.test.ts
+++ b/src/utils/metadata/index.test.ts
@@ -13,19 +13,11 @@ import { eip137Namehash } from '../namehash';
 import { DomainTestHelper } from '../testing/DomainTestHelper';
 
 describe('getAttributeType', () => {
-  it('should return subdomain', async () => {
+  it('should return subdomain', () => {
     const domainNames = ['test.testing.nft', 'efef.efff.x', 'wef.efe.f.ef.0.x'];
     for (const domainName of domainNames) {
-      expect(await getAttributeType(new Domain({ name: domainName }))).to.equal(
+      expect(getAttributeType(new Domain({ name: domainName }))).to.equal(
         AttributeType.Subdomain,
-      );
-    }
-  });
-  it('should return clean', async () => {
-    const domainNames = ['test.nft', 'tsioerj.x'];
-    for (const domainName of domainNames) {
-      expect(await getAttributeType(new Domain({ name: domainName }))).to.equal(
-        AttributeType.Clean,
       );
     }
   });

--- a/src/utils/metadata/index.test.ts
+++ b/src/utils/metadata/index.test.ts
@@ -42,7 +42,7 @@ describe('getAttributeType', () => {
     });
     subdomain.parent = domain;
     await subdomain.save();
-    expect(await getAttributeType(domain)).to.be.equal(AttributeType.Standard);
+    expect(getAttributeType(domain)).to.be.equal(AttributeType.Standard);
   });
 });
 

--- a/src/utils/metadata/index.test.ts
+++ b/src/utils/metadata/index.test.ts
@@ -8,23 +8,57 @@ import {
   AttributeType,
 } from '.';
 import { Domain } from '../../models';
+import { Blockchain } from '../../types/common';
+import { eip137Namehash } from '../namehash';
+import { DomainTestHelper } from '../testing/DomainTestHelper';
 
 describe('getAttributeType', () => {
-  it('should return subdomain', () => {
+  it('should return subdomain', async () => {
     const domainNames = ['test.testing.nft', 'efef.efff.x', 'wef.efe.f.ef.0.x'];
     for (const domainName of domainNames) {
-      expect(getAttributeType(new Domain({ name: domainName }))).to.equal(
+      expect(await getAttributeType(new Domain({ name: domainName }))).to.equal(
         AttributeType.Subdomain,
       );
     }
   });
-  it('should return standard', () => {
+  it('should return standard', async () => {
     const domainNames = ['test.nft', 'efef.x', 'x'];
     for (const domainName of domainNames) {
-      expect(getAttributeType(new Domain({ name: domainName }))).to.equal(
+      expect(await getAttributeType(new Domain({ name: domainName }))).to.equal(
         AttributeType.Standard,
       );
     }
+  });
+  it('should return clean', async () => {
+    const domainNames = ['test.nft', 'tsioerj.x'];
+    for (const domainName of domainNames) {
+      expect(await getAttributeType(new Domain({ name: domainName }))).to.equal(
+        AttributeType.Clean,
+      );
+    }
+  });
+  it('should return standard', async () => {
+    const { domain } = await DomainTestHelper.createTestDomain({
+      name: 'test.nft',
+      node: eip137Namehash('test.nft'),
+      ownerAddress: '0x8aaD44321A86b170879d7A244c1e8d360c99DdA8',
+      blockchain: Blockchain.ETH,
+      networkId: 1337,
+      registry: '0xd1e5b0ff1287aa9f9a268759062e4ab08b9dacbe',
+      resolver: '0xd1e5b0ff1287aa9f9a268759062e4ab08b9dacbe',
+    });
+    const { domain: subdomain } = await DomainTestHelper.createTestDomain({
+      name: 'sub.test.nft',
+      node: eip137Namehash('sub.test.nft'),
+      ownerAddress: '0x8aaD44321A86b170879d7A244c1e8d360c99DdA8',
+      blockchain: Blockchain.ETH,
+      networkId: 1337,
+      registry: '0xd1e5b0ff1287aa9f9a268759062e4ab08b9dacbe',
+      resolver: '0xd1e5b0ff1287aa9f9a268759062e4ab08b9dacbe',
+    });
+    subdomain.parent = domain;
+    await subdomain.save();
+    expect(await getAttributeType(domain)).to.be.equal(AttributeType.Standard);
   });
 });
 

--- a/src/utils/metadata/index.test.ts
+++ b/src/utils/metadata/index.test.ts
@@ -21,14 +21,6 @@ describe('getAttributeType', () => {
       );
     }
   });
-  it('should return standard', async () => {
-    const domainNames = ['test.nft', 'efef.x', 'x'];
-    for (const domainName of domainNames) {
-      expect(await getAttributeType(new Domain({ name: domainName }))).to.equal(
-        AttributeType.Standard,
-      );
-    }
-  });
   it('should return clean', async () => {
     const domainNames = ['test.nft', 'tsioerj.x'];
     for (const domainName of domainNames) {

--- a/src/utils/metadata/index.ts
+++ b/src/utils/metadata/index.ts
@@ -35,6 +35,7 @@ export enum AttributeType {
   Subdomain = 'subdomain',
   Animal = 'animal',
   Premium = 'premium',
+  Clean = 'clean', // domain has no subdomains
 }
 
 export enum AttributeCategory {
@@ -95,7 +96,9 @@ export const getAttributeCategory = (
   return getNumberClub(domain);
 };
 
-export const getAttributeType = (domain: Domain): AttributeType => {
+export const getAttributeType = async (
+  domain: Domain,
+): Promise<AttributeType> => {
   const AnimalHelper: AnimalDomainHelper = new AnimalDomainHelper();
   if (PremiumDomains.includes(domain.name)) {
     return AttributeType.Premium;
@@ -105,6 +108,9 @@ export const getAttributeType = (domain: Domain): AttributeType => {
   }
   if (domain.level > 2) {
     return AttributeType.Subdomain;
+  }
+  if ((await Domain.getChildrenCountByParentName(domain.name)) === 0) {
+    return AttributeType.Clean;
   }
   return AttributeType.Standard;
 };

--- a/src/utils/metadata/index.ts
+++ b/src/utils/metadata/index.ts
@@ -17,6 +17,7 @@ export enum DomainAttributeTrait {
   Type = 'Type',
   Picture = 'Picture',
   AttributeCharacterSet = 'Character Set',
+  Subdomains = 'Subdomains',
 }
 
 export enum AttributePictureType {
@@ -35,7 +36,6 @@ export enum AttributeType {
   Subdomain = 'subdomain',
   Animal = 'animal',
   Premium = 'premium',
-  Clean = 'clean', // domain has no subdomains
 }
 
 export enum AttributeCategory {
@@ -96,9 +96,7 @@ export const getAttributeCategory = (
   return getNumberClub(domain);
 };
 
-export const getAttributeType = async (
-  domain: Domain,
-): Promise<AttributeType> => {
+export const getAttributeType = (domain: Domain): AttributeType => {
   const AnimalHelper: AnimalDomainHelper = new AnimalDomainHelper();
   if (PremiumDomains.includes(domain.name)) {
     return AttributeType.Premium;
@@ -108,9 +106,6 @@ export const getAttributeType = async (
   }
   if (domain.level > 2) {
     return AttributeType.Subdomain;
-  }
-  if (!(await Domain.isNameParentOfChild(domain.name))) {
-    return AttributeType.Clean;
   }
   return AttributeType.Standard;
 };

--- a/src/utils/metadata/index.ts
+++ b/src/utils/metadata/index.ts
@@ -109,7 +109,7 @@ export const getAttributeType = async (
   if (domain.level > 2) {
     return AttributeType.Subdomain;
   }
-  if ((await Domain.getChildrenCountByParentName(domain.name)) === 0) {
+  if (!(await Domain.isNameParentOfChild(domain.name))) {
     return AttributeType.Clean;
   }
   return AttributeType.Standard;


### PR DESCRIPTION
Adds subdomains attribute type

MetadataController.getAttributeType is now async

<img width="333" alt="Screen Shot 2022-12-08 at 8 42 18 AM" src="https://user-images.githubusercontent.com/23408540/206511607-535f65b5-d5f6-4b1d-8a9c-c3fd04e9ae27.png">
Will display "subdomains" attribute next to length and level attributes to show the # of subdomains issued by a domain
