### PR TITLE
Add support for N-th level domains metadata

### DIFF
--- a/src/controllers/MetaDataController.ts
+++ b/src/controllers/MetaDataController.ts
@@ -402,16 +402,11 @@ export class MetaDataController {
       return "This is the only TLD on the Unstoppable registry. It's not owned by anyone.".concat(
         ipfsDescriptionPart,
       );
-    } else if (domain.level === 2 || domain.level === 3) {
-      const description = belongsToTld(domain.name, UnstoppableDomainTlds.Coin)
-        ? '.coin domains are no longer supported by Unstoppable Domains. As a result, records of such domains cannot be updated. Learn more at our blog: https://unstoppabledomains.com/blog/coin. '
-        : 'A CNS or UNS blockchain domain. Use it to resolve your cryptocurrency addresses and decentralized websites.';
-      return description.concat(ipfsDescriptionPart);
     }
-
-    return 'BE CAREFUL! This is a subdomain. Even after purchasing this name, the parent domain has the right to revoke ownership of this domain at anytime. Unless the parent is a smart contract specifically designed otherwise.'.concat(
-      ipfsDescriptionPart,
-    );
+    const description = belongsToTld(domain.name, UnstoppableDomainTlds.Coin)
+      ? '.coin domains are no longer supported by Unstoppable Domains. As a result, records of such domains cannot be updated. Learn more at our blog: https://unstoppabledomains.com/blog/coin. '
+      : 'A CNS or UNS blockchain domain. Use it to resolve your cryptocurrency addresses and decentralized websites.';
+    return description.concat(ipfsDescriptionPart);
   }
 
   private getIpfsDescriptionPart(records: Record<string, string>): string {


### PR DESCRIPTION
## Background

Sub-domains beyond 3rd level currently display irrelevant meta description. https://metadata.unstoppabledomains.com/metadata/75571271018839502342716184260064368209464283170732561149932609752770037560070

## Changes

1. Allow meta-description for all levels of UD domains


## Code Review

This Pull Request was thoroughly reviewed and meets all Code Review Standards pertaining to:

- [x] **Implementation** - satisfied acceptance criteria
- [x] **Communication** - notified engineers/stakeholders about impactful changes
- [ ] **Error handling** - handled, logged & alerted on errors
- [x] **Documentation** - wrote readable code & commits, documented unintuitive code
- [x] **Testing** - unit & E2E test coverage, tested in staging, DB migrations backwards compatible
- [ ] **Security** - sanitized inputs, vetted dependencies, validated/secured API requests, no committed secrets
- [ ] **Performance** - optimized expensive algorithms & database queries

Please select all **applied** standards relevant to this PR.
## Confirmation

- [x] **Assignee Confirmation** - I (the author) have filled out the template above
- [ ] **Reviewer Confirmation** - I (a/the reviewer) confirm 1) the author has filled out the template and checked the box that says **Assignee Confirmation** 2) I reviewed the code and selected all applicable items in the code review section.
