### PR TITLE
[DT-984] fix: Created migration script to update subdomains parent ids to point to domains instead of tlds

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "prepare": "husky install",
     "typeorm": "ts-node -T node_modules/.bin/typeorm",
     "db:migration:sync": "yarn db:migration:pending && yarn typeorm migration:generate -n",
-    "db:migration:new": "yarn typeorm migration:create -n",
+    "db:migration:new": "yarn typeorm migration:create -d ./src/database/migrations/ -n",
     "db:migration:run": "yarn typeorm migration:run",
     "db:migration:revert": "yarn typeorm migration:revert",
     "db:migration:pending": "yarn typeorm migration:show | (! grep -E '\\[ \\]' )",

--- a/src/database/migrations/1670969428141-UpdateDomainParents.ts
+++ b/src/database/migrations/1670969428141-UpdateDomainParents.ts
@@ -1,0 +1,114 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+import { logger } from '../../logger';
+
+export class UpdateDomainParents1670969428141 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    try {
+      await queryRunner.query(`
+        CREATE FUNCTION sld_of_domain(domainName text)
+          returns text
+          language plpgsql
+          as
+          $$
+          declare
+            split_domain_name_array TEXT[];
+            result TEXT;
+          BEGIN
+            SELECT 
+              regexp_split_to_array(domainName, E'\\\\.')
+            INTO 
+              split_domain_name_array
+            ;
+            SELECT CASE
+              WHEN 
+                array_length(split_domain_name_array, 1) > 2 
+              THEN 
+                array_to_string(
+                  split_domain_name_array[
+                    (array_length(split_domain_name_array, 1) - 1)
+                    :
+                    array_length(split_domain_name_array, 1)
+                  ],
+                  '.'
+                )
+              ELSE 
+                split_domain_name_array[array_length(split_domain_name_array, 1)]
+              END 
+            INTO result;
+            return result;
+          END;
+        $$;
+  
+        UPDATE 
+          domains
+        SET
+          parent_id = parent.id
+        FROM
+          domains domain
+        JOIN
+          domains parent
+        ON 
+          sld_of_domain(domain.name)=parent.name
+        WHERE 
+          domains.parent_id IS NOT NULL
+        AND
+          array_length(regexp_split_to_array(domains.name, E'\\\\.'), 1) > 2
+        AND
+          domains.name = domain.name;
+      
+        DROP FUNCTION sld_of_domain;
+      `);
+    } catch (error: any) {
+      logger.error('Unsuccessful Migration was ran', error);
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    try {
+      await queryRunner.query(`
+        CREATE FUNCTION previous_sld_of_domain(domainName text)
+          returns text
+          language plpgsql
+          as
+          $$
+          declare
+            split_domain_name_array TEXT[];
+            result TEXT;
+          BEGIN
+            SELECT 
+              regexp_split_to_array(domainName, E'\\\\.')
+            INTO 
+              split_domain_name_array;
+            SELECT 
+              split_domain_name_array[array_length(split_domain_name_array, 1)] 
+            INTO 
+              result
+            ;
+            return result;
+          END;
+        $$;
+
+        UPDATE 
+          domains
+        SET
+          parent_id = parent.id
+        FROM
+          domains domain
+        JOIN
+          domains parent
+        ON 
+          previous_sld_of_domain(domain.name)=parent.name
+        WHERE 
+          domains.parent_id IS NOT NULL
+        AND
+          array_length(regexp_split_to_array(domains.name, E'\\\\.'), 1) > 2
+        AND
+          domains.name = domain.name;
+
+        DROP FUNCTION previous_sld_of_domain;
+      `);
+    } catch (error: any) {
+      logger.error('Unsuccessful Migration was ran', error);
+    }
+  }
+}


### PR DESCRIPTION
<!--
PLEASE FILL THIS OUT UNLESS THE PR HAS ONLY MINOR CHANGES. KEEP YOUR PR IN DRAFT MODE UNTIL READY FOR REVIEW.

> conventional_commit_tag: Description

Follow the above format for your Pull Request's title, where conventional_commit_tag is a Conventional Commit tag (appended with ! for breaking changes), and Description is a short description of your changes.

Conventional Commit tag reference: https://github.com/pvdlg/conventional-changelog-metahub#commit-types

If you have ideas for how to improve this template, please open a PR. The template is located in the `.github` folder.
-->

## Background

Current subdomains in the resolution_service.domains table have incorrect parent ids.

## Changes

introduce migration script to be ran to update the resolution_service.domains table

## To Do
- [ ] Fix subdomain insertions into the domains table to have correct parent ids [DT-985](https://linear.app/unstoppable-domains/issue/DT-985/fix-subdomain-parent-id-insertions)
<!--
List any remaining work for this PR. If there are no todos, you can delete this section. If there are any non-trivial todos, keep in draft mode.

For example:
- [ ] Rebase against master once #9999 is merged
- [ ] Fix flakey test
-->

## Additional Deployment and/or Rollback Steps

<!--
List any additional steps to deploy/rollback beyond the normal workflow:

For example:
- Deploy PR 1234, then this PR
- Revert PR 1234, then revert this PR
-->

## Code Review

This Pull Request was thoroughly reviewed and meets all Code Review Standards pertaining to:

- [ ] **Implementation** - satisfied acceptance criteria
- [ ] **Communication** - notified engineers/stakeholders about impactful changes
- [ ] **Error handling** - handled, logged & alerted on errors
- [ ] **Documentation** - wrote readable code & commits, documented unintuitive code
- [ ] **Testing** - unit & E2E test coverage, tested in staging, DB migrations backwards compatible
- [ ] **Security** - sanitized inputs, vetted dependencies, validated/secured API requests, no committed secrets
- [ ] **Performance** - optimized expensive algorithms & database queries

Please select all **applied** standards relevant to this PR.
## Confirmation

- [ ] **Assignee Confirmation** - I (the author) have filled out the template above
- [ ] **Reviewer Confirmation** - I (a/the reviewer) confirm 1) the author has filled out the template and checked the box that says **Assignee Confirmation** 2) I reviewed the code and selected all applicable items in the code review section.
