### PR TITLE
Adding 200ms timeout to profile image fetches

### DIFF
--- a/src/utils/AnimalDomainHelper/AnimalDomainHelper.ts
+++ b/src/utils/AnimalDomainHelper/AnimalDomainHelper.ts
@@ -8,6 +8,7 @@ import {
   CustomImageDomains,
   DomainAttributeTrait,
 } from '../metadata';
+import { PROFILE_FETCH_TIMEOUT_MS } from '../common';
 
 export type OpenSeaMetadataAttribute =
   | { trait_type?: DomainAttributeTrait; value: string | number }
@@ -58,7 +59,7 @@ export default class AnimalDomainHelper {
   async getAnimalImageData(domainName: string): Promise<string | undefined> {
     const imageUrl = this.getAnimalImageUrl(domainName);
     if (imageUrl) {
-      const ret = await fetch(imageUrl, { timeout: 200 });
+      const ret = await fetch(imageUrl, { timeout: PROFILE_FETCH_TIMEOUT_MS });
       return ret.text();
     }
   }

--- a/src/utils/AnimalDomainHelper/AnimalDomainHelper.ts
+++ b/src/utils/AnimalDomainHelper/AnimalDomainHelper.ts
@@ -58,7 +58,7 @@ export default class AnimalDomainHelper {
   async getAnimalImageData(domainName: string): Promise<string | undefined> {
     const imageUrl = this.getAnimalImageUrl(domainName);
     if (imageUrl) {
-      const ret = await fetch(imageUrl);
+      const ret = await fetch(imageUrl, { timeout: 200 });
       return ret.text();
     }
   }

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,3 +1,5 @@
 export function convertToArray<T>(val: T | T[]): T[] {
   return Array.isArray(val) ? val : [val];
 }
+
+export const PROFILE_FETCH_TIMEOUT_MS = 200;

--- a/src/utils/socialPicture/index.ts
+++ b/src/utils/socialPicture/index.ts
@@ -299,7 +299,7 @@ export const getOffChainProfileImage = async (
   let response;
 
   try {
-    response = await (await nodeFetch(url)).json();
+    response = await (await nodeFetch(url, { timeout: 200 })).json();
   } catch (error) {
     logger.error(`Failed to fetch offchain profile for: ${url}`);
     logger.error(`Profile Fetching error: ${error}`);
@@ -355,7 +355,7 @@ export const getOnChainProfileImage = async (
     imagePathFromDomain.endsWith('.svg')
   ) {
     try {
-      const ret = await nodeFetch(imagePathFromDomain);
+      const ret = await nodeFetch(imagePathFromDomain, { timeout: 200 });
       profileImageSVG = await ret.text();
     } catch (error) {
       logger.error(

--- a/src/utils/socialPicture/index.ts
+++ b/src/utils/socialPicture/index.ts
@@ -10,6 +10,7 @@ import { env } from '../../env';
 import { Storage } from '@google-cloud/storage';
 import { logger } from '../../logger';
 import { MetadataService } from '../../services/MetadataService';
+import { PROFILE_FETCH_TIMEOUT_MS } from '../common';
 
 export type SocialPictureOptions = {
   chainId: string;
@@ -299,7 +300,9 @@ export const getOffChainProfileImage = async (
   let response;
 
   try {
-    response = await (await nodeFetch(url, { timeout: 200 })).json();
+    response = await (
+      await nodeFetch(url, { timeout: PROFILE_FETCH_TIMEOUT_MS })
+    ).json();
   } catch (error) {
     logger.error(`Failed to fetch offchain profile for: ${url}`);
     logger.error(`Profile Fetching error: ${error}`);
@@ -355,7 +358,9 @@ export const getOnChainProfileImage = async (
     imagePathFromDomain.endsWith('.svg')
   ) {
     try {
-      const ret = await nodeFetch(imagePathFromDomain, { timeout: 200 });
+      const ret = await nodeFetch(imagePathFromDomain, {
+        timeout: PROFILE_FETCH_TIMEOUT_MS,
+      });
       profileImageSVG = await ret.text();
     } catch (error) {
       logger.error(


### PR DESCRIPTION
We're been seeing an elevated number of image-src requests, including ones that take a very long time to execute.

## Background

[This](https://unstoppable.pagerduty.com/incidents/Q26L8VH48RGJ1C?utm_campaign=channel&utm_source=slack) example alert is one of the many that fired recently.  The latency seems to be caused by /image-src requests that take a long time to execute.

## Changes

We added 200ms timeout values to each of the external requests that the /image-src endpoint could call.  This means worst-case scenario, the request will spend 600ms looking for external data, rather than the 1000+ seconds it's taking now.  This should keep the worst-case total request time around 600ms, which is half our lowest alert limit of 1200ms.

## Code Review

This Pull Request was thoroughly reviewed and meets all Code Review Standards pertaining to:

- [x] **Implementation** - satisfied acceptance criteria
- [x] **Communication** - notified engineers/stakeholders about impactful changes
- [x] **Error handling** - handled, logged & alerted on errors
- [x] **Documentation** - wrote readable code & commits, documented unintuitive code
- [x] **Testing** - unit & E2E test coverage, tested in staging, DB migrations backwards compatible
- [x] **Security** - sanitized inputs, vetted dependencies, validated/secured API requests, no committed secrets
- [x] **Performance** - optimized expensive algorithms & database queries

Please select all **applied** standards relevant to this PR.
## Confirmation

- [x] **Assignee Confirmation** - I (the author) have filled out the template above
- [ ] **Reviewer Confirmation** - I (a/the reviewer) confirm 1) the author has filled out the template and checked the box that says **Assignee Confirmation** 2) I reviewed the code and selected all applicable items in the code review section.
