### PR TITLE
[SRE-1011] chore: Adjust settings and make configurable

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -35,8 +35,8 @@ steps:
       - "--cpu=2000m"
       - "--memory=1024Mi"
       - "--min-instances=$_MIN_INSTANCES"
-      - "--max-instances=80"
-      - "--concurrency=40"
+      - "--max-instances=$_MAX_INSTANCES"
+      - "--concurrency=$_MAX_CONCURRENCY"
       - "--port=3000"
       #- "--vpc-connector=projects/unstoppable-domains-staging/locations/us-central1/connectors/vpc-serverless"
       - "--vpc-connector=$_VPC_SERVERLESS"
@@ -97,7 +97,7 @@ steps:
       - "--cpu=2000m"
       - "--memory=1024Mi"
       - "--min-instances=$_MIN_INSTANCES"
-      - "--max-instances=80"
+      - "--max-instances=$_MAX_INSTANCES"
       - "--port=3000"
       - "--vpc-connector=$_VPC_SERVERLESS"
       - "--vpc-egress=private-ranges-only"
@@ -246,6 +246,8 @@ substitutions:
   _RESOLUTION_SERVICE_POSTGRES_HOST: TBD
   _SKIP_DEPLOY_WORKER: "true"
   _MIN_INSTANCES: "1"
+  _MAX_INSTANCES: "80"
+  _MAX_CONCURRENCY: "80"
 tags:
   - gcp-cloud-build-deploy-cloud-run
   - resolution-service


### PR DESCRIPTION
## Background

Revert GCR settings to relieve some db pressure and made the settings configurable
https://linear.app/unstoppable-domains/issue/SRE-1011/update-resolution-service-gcr-configuration

## Changes

Revert concurreny to 80 (was 40) and made concurrency and max instances configurable from the cloud build trigger

## Code Review

This Pull Request was thoroughly reviewed and meets all Code Review Standards pertaining to:

- [ ] **Implementation** - satisfied acceptance criteria
- [ ] **Communication** - notified engineers/stakeholders about impactful changes
- [ ] **Error handling** - handled, logged & alerted on errors
- [ ] **Documentation** - wrote readable code & commits, documented unintuitive code
- [ ] **Testing** - unit & E2E test coverage, tested in staging, DB migrations backwards compatible
- [ ] **Security** - sanitized inputs, vetted dependencies, validated/secured API requests, no committed secrets
- [ ] **Performance** - optimized expensive algorithms & database queries

Please select all **applied** standards relevant to this PR.
## Confirmation

- [ ] **Assignee Confirmation** - I (the author) have filled out the template above
- [ ] **Reviewer Confirmation** - I (a/the reviewer) confirm 1) the author has filled out the template and checked the box that says **Assignee Confirmation** 2) I reviewed the code and selected all applicable items in the code review section.
