### PR TITLE
[DT-1168] feat: Replace status endpoint block count with update time

### DIFF
--- a/src/controllers/StatusController.test.ts
+++ b/src/controllers/StatusController.test.ts
@@ -1,44 +1,10 @@
 import supertest from 'supertest';
 import { api } from '../api';
 import { expect } from 'chai';
-import nock from 'nock';
 import { WorkerStatus } from '../models';
-import * as sinon from 'sinon';
-import * as ProviderModule from '../workers/eth/EthereumProvider';
 import { Blockchain } from '../types/common';
-import { env } from '../env';
-import ZilProvider from '../workers/zil/ZilProvider';
-
-const mockEthJsonRpcProviderUrl = 'http://test.jsonrpc.provider:8545';
-const mockMaticJsonRpcProviderUrl = 'http://test.jsonrpc.provider:8546';
 
 describe('StatusController', () => {
-  const sinonSandbox = sinon.createSandbox();
-
-  before(() => {
-    sinonSandbox // Nock behaves really weirdly when mocking localhost, so we mock the provider to not use localhost at all
-      .stub(ProviderModule, 'EthereumProvider')
-      .value(
-        new ProviderModule.StaticJsonRpcProvider(mockEthJsonRpcProviderUrl, {
-          name: '',
-          chainId: 99,
-        }),
-      );
-
-    sinonSandbox // Nock behaves really weirdly when mocking localhost, so we mock the provider to not use localhost at all
-      .stub(ProviderModule, 'MaticProvider')
-      .value(
-        new ProviderModule.StaticJsonRpcProvider(mockMaticJsonRpcProviderUrl, {
-          name: '',
-          chainId: 99,
-        }),
-      );
-  });
-
-  after(() => {
-    sinonSandbox.restore();
-  });
-
   describe('HEAD /', () => {
     it('should return empty body', async () => {
       const response = await supertest(api)
@@ -59,294 +25,77 @@ describe('StatusController', () => {
       .expect('Location', '/api-docs');
   });
 
-  it('should return appropriate block counts', async () => {
-    const expectedStatus = {
-      blockchain: {
-        ETH: {
-          acceptableDelayInBlocks: 100,
-          latestMirroredBlock: 901,
-          latestNetworkBlock: 1207,
-          networkId: 1337,
-          isUpToDate: false,
-        },
-        MATIC: {
-          acceptableDelayInBlocks: 100,
-          latestMirroredBlock: 12145,
-          latestNetworkBlock: 12375,
-          networkId: 1337,
-          isUpToDate: false,
-        },
-        ZIL: {
-          acceptableDelayInBlocks: 20,
-          latestMirroredBlock: 171102,
-          latestNetworkBlock: 171127,
-          networkId: 333,
-          isUpToDate: false,
+  describe('/status', () => {
+    const testCases = [
+      {
+        name: 'should return appropriate status',
+        expectedStatusBody: {
+          blockchain: {
+            ETH: {
+              latestMirroredBlock: 901,
+              lastUpdated: new Date().getTime(),
+              networkId: 1337,
+              isUpToDate: true,
+            },
+            MATIC: {
+              latestMirroredBlock: 12145,
+              lastUpdated: new Date().getTime(),
+              networkId: 1337,
+              isUpToDate: true,
+            },
+            ZIL: {
+              latestMirroredBlock: 171102,
+              lastUpdated: new Date().getTime(),
+              networkId: 333,
+              isUpToDate: true,
+            },
+          },
         },
       },
-    };
+      {
+        name: 'should return false for outdated statuses',
+        expectedStatusBody: {
+          blockchain: {
+            ETH: {
+              latestMirroredBlock: 901,
+              lastUpdated: new Date().getTime() - 3600000,
+              networkId: 1337,
+              isUpToDate: false,
+            },
+            MATIC: {
+              latestMirroredBlock: 12145,
+              lastUpdated: new Date().getTime() - 3600000,
+              networkId: 1337,
+              isUpToDate: false,
+            },
+            ZIL: {
+              latestMirroredBlock: 171102,
+              lastUpdated: new Date().getTime() - 3600000,
+              networkId: 333,
+              isUpToDate: false,
+            },
+          },
+        },
+      },
+    ];
 
-    const viewBlockInterceptor = createViewBlockInterceptor(
-      expectedStatus.blockchain.ZIL.latestMirroredBlock,
-      expectedStatus.blockchain.ZIL.latestNetworkBlock,
-    );
-    const jsonRpcInterceptor = createEthereumInterceptor(
-      expectedStatus.blockchain.ETH.latestNetworkBlock,
-    );
-    const maticRpcInterceptor = createMaticInterceptor(
-      expectedStatus.blockchain.MATIC.latestNetworkBlock,
-    );
-    await WorkerStatus.saveWorkerStatus(
-      Blockchain.ETH,
-      expectedStatus.blockchain.ETH.latestMirroredBlock,
-      undefined,
-      undefined,
-    );
-    await WorkerStatus.saveWorkerStatus(
-      Blockchain.MATIC,
-      expectedStatus.blockchain.MATIC.latestMirroredBlock,
-      undefined,
-      undefined,
-    );
-    await WorkerStatus.saveWorkerStatus(
-      Blockchain.ZIL,
-      expectedStatus.blockchain.ZIL.latestMirroredBlock,
-      undefined,
-      undefined,
-    );
+    testCases.forEach((test) => {
+      it(test.name, async () => {
+        for (const key in test.expectedStatusBody.blockchain) {
+          const status = test.expectedStatusBody.blockchain[key as Blockchain];
+          await new WorkerStatus({
+            updatedAt: new Date(status.lastUpdated),
+            location: key as Blockchain,
+            lastMirroredBlockNumber: status.latestMirroredBlock,
+          }).save();
+        }
 
-    const res = await supertest(api).get('/status').send();
+        const res = await supertest(api).get('/status').send();
 
-    viewBlockInterceptor.done();
-    jsonRpcInterceptor.done();
-    maticRpcInterceptor.done();
-
-    expect(res.body).containSubset(expectedStatus);
-    expect(res.status).eq(200);
-  });
-
-  it("should return isUpToDate = false if ETH and ZIL mirror aren't up to date", async () => {
-    const latestNetworkBlock = 301;
-    const latestMirroredBlock = 100;
-    const viewBlockInterceptor = createViewBlockInterceptor(
-      latestMirroredBlock,
-      latestNetworkBlock,
-    );
-    const jsonRpcInterceptor = createEthereumInterceptor(latestNetworkBlock);
-    const maticRpcInterceptor = createMaticInterceptor(latestNetworkBlock);
-    await WorkerStatus.saveWorkerStatus(
-      Blockchain.ETH,
-      latestMirroredBlock,
-      undefined,
-      undefined,
-    );
-    await WorkerStatus.saveWorkerStatus(
-      Blockchain.MATIC,
-      latestMirroredBlock,
-      undefined,
-      undefined,
-    );
-    await WorkerStatus.saveWorkerStatus(
-      Blockchain.ZIL,
-      latestMirroredBlock,
-      undefined,
-      undefined,
-    );
-    const res = await supertest(api).get('/status').send();
-    viewBlockInterceptor.done();
-    jsonRpcInterceptor.done();
-    maticRpcInterceptor.done();
-    expect(res.status).eq(200);
-    expect(res.body.blockchain.ETH.isUpToDate).to.be.false;
-    expect(res.body.blockchain.MATIC.isUpToDate).to.be.false;
-    expect(res.body.blockchain.ZIL.isUpToDate).to.be.false;
-  });
-
-  it('should return isUpToDate = true if ZNS and ETH mirror are up to date', async () => {
-    const latestNetworkBlock = 200;
-    const latestMirroredBlock = 123;
-    const viewBlockInterceptor = createViewBlockInterceptor(
-      latestMirroredBlock,
-      latestMirroredBlock,
-    );
-    const jsonRpcInterceptor = createEthereumInterceptor(latestNetworkBlock);
-    const maticRpcInterceptor = createMaticInterceptor(latestNetworkBlock);
-    await WorkerStatus.saveWorkerStatus(
-      Blockchain.ETH,
-      latestMirroredBlock,
-      undefined,
-      undefined,
-    );
-    await WorkerStatus.saveWorkerStatus(
-      Blockchain.MATIC,
-      latestMirroredBlock,
-      undefined,
-      undefined,
-    );
-    await WorkerStatus.saveWorkerStatus(
-      Blockchain.ZIL,
-      latestMirroredBlock,
-      undefined,
-      undefined,
-    );
-    const res = await supertest(api).get('/status').send();
-    viewBlockInterceptor.done();
-    jsonRpcInterceptor.done();
-    maticRpcInterceptor.done();
-    expect(res.status).eq(200);
-    expect(res.body.blockchain.ETH.isUpToDate).to.be.true;
-    expect(res.body.blockchain.MATIC.isUpToDate).to.be.true;
-    expect(res.body.blockchain.ZIL.isUpToDate).to.be.true;
-  });
-
-  it("should return isUpToDate = false if ETH mirror isn't up to date", async () => {
-    const latestNetworkBlock = 200;
-    const latestMirroredBlock = 120;
-    const viewBlockInterceptor = createViewBlockInterceptor(
-      latestMirroredBlock,
-      latestMirroredBlock,
-    );
-    const jsonRpcInterceptor = createEthereumInterceptor(latestNetworkBlock);
-    const maticRpcInterceptor = createMaticInterceptor(latestNetworkBlock);
-    await WorkerStatus.saveWorkerStatus(
-      Blockchain.ETH,
-      latestMirroredBlock - 100,
-      undefined,
-      undefined,
-    );
-    await WorkerStatus.saveWorkerStatus(
-      Blockchain.MATIC,
-      latestMirroredBlock,
-      undefined,
-      undefined,
-    );
-    await WorkerStatus.saveWorkerStatus(
-      Blockchain.ZIL,
-      latestMirroredBlock,
-      undefined,
-      undefined,
-    );
-    const res = await supertest(api).get('/status').send();
-    viewBlockInterceptor.done();
-    jsonRpcInterceptor.done();
-    maticRpcInterceptor.done();
-    expect(res.status).eq(200);
-    expect(res.body.blockchain.ETH.isUpToDate).to.be.false;
-    expect(res.body.blockchain.MATIC.isUpToDate).to.be.true;
-    expect(res.body.blockchain.ZIL.isUpToDate).to.be.true;
-  });
-
-  it("should return isUpToDate = false if ZNS mirror isn't up to date", async () => {
-    const latestNetworkBlock = 300;
-    const latestMirroredBlock = 220;
-    const viewBlockInterceptor = createViewBlockInterceptor(
-      latestMirroredBlock,
-      latestNetworkBlock,
-    );
-    const jsonRpcInterceptor = createEthereumInterceptor(latestNetworkBlock);
-    const maticRpcInterceptor = createMaticInterceptor(latestNetworkBlock);
-    await WorkerStatus.saveWorkerStatus(
-      Blockchain.ETH,
-      latestMirroredBlock,
-      undefined,
-      undefined,
-    );
-    await WorkerStatus.saveWorkerStatus(
-      Blockchain.MATIC,
-      latestMirroredBlock,
-      undefined,
-      undefined,
-    );
-    await WorkerStatus.saveWorkerStatus(
-      Blockchain.ZIL,
-      latestMirroredBlock,
-      undefined,
-      undefined,
-    );
-    const res = await supertest(api).get('/status').send();
-    viewBlockInterceptor.done();
-    jsonRpcInterceptor.done();
-    maticRpcInterceptor.done();
-    expect(res.status).eq(200);
-    expect(res.body.blockchain.ETH.isUpToDate).to.be.true;
-    expect(res.body.blockchain.MATIC.isUpToDate).to.be.true;
-    expect(res.body.blockchain.ZIL.isUpToDate).to.be.false;
-  });
-
-  it("should return isUpToDate = false if MATIC mirror isn't up to date", async () => {
-    const latestNetworkBlock = 300;
-    const latestMirroredBlock = 220;
-    const viewBlockInterceptor = createViewBlockInterceptor(
-      latestMirroredBlock,
-      latestMirroredBlock,
-    );
-    const jsonRpcInterceptor = createEthereumInterceptor(latestNetworkBlock);
-    const maticRpcInterceptor = createMaticInterceptor(latestNetworkBlock);
-    await WorkerStatus.saveWorkerStatus(
-      Blockchain.ETH,
-      latestMirroredBlock,
-      undefined,
-      undefined,
-    );
-    await WorkerStatus.saveWorkerStatus(
-      Blockchain.MATIC,
-      latestMirroredBlock - 100,
-      undefined,
-      undefined,
-    );
-    await WorkerStatus.saveWorkerStatus(
-      Blockchain.ZIL,
-      latestMirroredBlock,
-      undefined,
-      undefined,
-    );
-    const res = await supertest(api).get('/status').send();
-    viewBlockInterceptor.done();
-    jsonRpcInterceptor.done();
-    maticRpcInterceptor.done();
-    expect(res.status).eq(200);
-    expect(res.body.blockchain.ETH.isUpToDate).to.be.true;
-    expect(res.body.blockchain.MATIC.isUpToDate).to.be.false;
-    expect(res.body.blockchain.ZIL.isUpToDate).to.be.true;
-  });
-
-  it('should return isUpToDate = false if fetching status from provider failed', async () => {
-    const latestNetworkBlock = 300;
-    const latestMirroredBlock = 220;
-    const viewBlockInterceptor = createViewBlockInterceptor(
-      latestMirroredBlock,
-      latestMirroredBlock,
-      true,
-    );
-    const jsonRpcInterceptor = createEthereumInterceptor(latestNetworkBlock);
-    const maticRpcInterceptor = createMaticInterceptor(latestNetworkBlock);
-    await WorkerStatus.saveWorkerStatus(
-      Blockchain.ETH,
-      latestMirroredBlock,
-      undefined,
-      undefined,
-    );
-    await WorkerStatus.saveWorkerStatus(
-      Blockchain.MATIC,
-      latestMirroredBlock - 100,
-      undefined,
-      undefined,
-    );
-    await WorkerStatus.saveWorkerStatus(
-      Blockchain.ZIL,
-      latestMirroredBlock,
-      undefined,
-      undefined,
-    );
-    const res = await supertest(api).get('/status').send();
-    viewBlockInterceptor.done();
-    jsonRpcInterceptor.done();
-    maticRpcInterceptor.done();
-    expect(res.status).eq(200);
-    expect(res.body.blockchain.ETH.isUpToDate).to.be.true;
-    expect(res.body.blockchain.MATIC.isUpToDate).to.be.false;
-    expect(res.body.blockchain.ZIL.isUpToDate).to.be.false;
-    expect(res.body.blockchain.ZIL.latestNetworkBlock).to.be.eq(-1);
+        expect(res.body).containSubset(test.expectedStatusBody);
+        expect(res.status).eq(200);
+      });
+    });
   });
 
   it('should return ok for /liveness_check and /readiness_check endpoints', async () => {
@@ -382,79 +131,3 @@ describe('StatusController', () => {
     expect(response.body.tlds).to.have.members(expectedResponse.tlds);
   });
 });
-
-function createViewBlockInterceptor(
-  mirroredBlockNumber: number,
-  networkBlockNumber: number,
-  shouldRespondError = false,
-) {
-  return nock('https://api.viewblock.io')
-    .get(
-      `/v1/zilliqa/addresses/${env.APPLICATION.ZILLIQA.ZNS_REGISTRY_CONTRACT}/txs`,
-    )
-    .query({
-      network: 'testnet',
-      events: true,
-      atxuidFrom: mirroredBlockNumber,
-      atxuidTo: mirroredBlockNumber + 24,
-    })
-    .reply(
-      shouldRespondError ? 400 : 200,
-      generateViewBlockResponse(networkBlockNumber),
-    );
-}
-
-function createEthereumInterceptor(networkBlockNumber: number) {
-  return nock(mockEthJsonRpcProviderUrl)
-    .post('/', {
-      jsonrpc: '2.0',
-      method: 'eth_getBlockByNumber',
-      params: ['latest', false],
-      id: /^\d+$/,
-    })
-    .reply(200, () => generateEthRpcResponse(networkBlockNumber));
-}
-
-function createMaticInterceptor(networkBlockNumber: number) {
-  return nock(mockMaticJsonRpcProviderUrl)
-    .post('/', {
-      jsonrpc: '2.0',
-      method: 'eth_getBlockByNumber',
-      params: ['latest', false],
-      id: /^\d+$/,
-    })
-    .reply(200, () => generateEthRpcResponse(networkBlockNumber));
-}
-
-function generateViewBlockResponse(networkBlockNumber: number) {
-  return [
-    {
-      atxuid: networkBlockNumber,
-    },
-  ];
-}
-
-function generateEthRpcResponse(networkBlockNumber: number) {
-  return {
-    id: 1,
-    jsonrpc: '2.0',
-    result: {
-      //dummy block structure, since we request the whole block
-      difficulty: 3849295379889,
-      extraData:
-        '0x476574682f76312e302e312d39383130306634372f6c696e75782f676f312e34',
-      gasLimit: '0x3141592',
-      gasUsed: '0x21000',
-      hash: '0xf93283571ae16dcecbe1816adc126954a739350cd1523a1559eabeae155fbb63',
-      miner: '0x909755D480A27911cB7EeeB5edB918fae50883c0',
-      nonce: '0x1a455280001cc3f8',
-      number: networkBlockNumber,
-      parentHash:
-        '0x73d88d376f6b4d232d70dc950d9515fad3b5aa241937e362fdbfd74d1c901781',
-      timestamp: 1439799168,
-      transactions: [
-        '0x6f12399cc2cb42bed5b267899b08a847552e8c42a64f5eb128c1bcbd1974fb0c',
-      ],
-    },
-  };
-}

--- a/src/env.ts
+++ b/src/env.ts
@@ -63,7 +63,7 @@ export type EthUpdaterConfig = {
   RECORDS_PER_PAGE: number;
   FETCH_INTERVAL: number;
   MAX_REORG_SIZE: number;
-  ACCEPTABLE_DELAY_IN_BLOCKS: number;
+  ACCEPTABLE_DELAY_TIME_MS: number;
   RESYNC_FROM: number | undefined;
 };
 
@@ -129,9 +129,9 @@ export const env = {
         process.env.ETHEREUM_MAX_REORG_SIZE,
         200,
       ),
-      ACCEPTABLE_DELAY_IN_BLOCKS: parseNumberFromEnv(
-        process.env.ETHEREUM_ACCEPTABLE_DELAY_IN_BLOCKS,
-        100,
+      ACCEPTABLE_DELAY_TIME_MS: parseNumberFromEnv(
+        process.env.ETHEREUM_ACCEPTABLE_DELAY_TIME_MS,
+        300000,
       ),
       RESYNC_FROM: !isNaN(Number(process.env.ETHEREUM_RESYNC_FROM))
         ? Number(process.env.ETHEREUM_RESYNC_FROM)
@@ -172,9 +172,9 @@ export const env = {
         process.env.POLYGON_MAX_REORG_SIZE,
         200,
       ),
-      ACCEPTABLE_DELAY_IN_BLOCKS: parseNumberFromEnv(
-        process.env.POLYGON_ACCEPTABLE_DELAY_IN_BLOCKS,
-        100,
+      ACCEPTABLE_DELAY_TIME_MS: parseNumberFromEnv(
+        process.env.POLYGON_ACCEPTABLE_DELAY_TIME_MS,
+        300000,
       ),
       RESYNC_FROM: !isNaN(Number(process.env.POLYGON_RESYNC_FROM))
         ? Number(process.env.POLYGON_RESYNC_FROM)
@@ -194,9 +194,9 @@ export const env = {
       VIEWBLOCK_API_KEY: process.env.VIEWBLOCK_API_KEY,
       VIEWBLOCK_API_URL: 'https://api.viewblock.io/v1/zilliqa',
       FETCH_INTERVAL: parseNumberFromEnv(process.env.ZNS_FETCH_INTERVAL, 5000),
-      ACCEPTABLE_DELAY_IN_BLOCKS: parseNumberFromEnv(
-        process.env.ZILLIQA_ACCEPTABLE_DELAY_IN_BLOCKS,
-        20,
+      ACCEPTABLE_DELAY_TIME_MS: parseNumberFromEnv(
+        process.env.ZILLIQA_ACCEPTABLE_DELAY_TIME_MS,
+        300000,
       ),
       CONFIRMATION_BLOCKS: parseNumberFromEnv(
         process.env.ZILLIQA_CONFIRMATION_BLOCKS,


### PR DESCRIPTION

## Background

Some changes from #308 extracted into a separate PR.

## Changes

 - Use last update time instead of block number to reduce latency of `/status` endpoint.

## To Do

 - [ ] zil worker status does not work with this approach. Worker status is not updated on every worker cycle.

## Code Review

This Pull Request was thoroughly reviewed and meets all Code Review Standards pertaining to:

- [ ] **Implementation** - satisfied acceptance criteria
- [ ] **Communication** - notified engineers/stakeholders about impactful changes
- [ ] **Error handling** - handled, logged & alerted on errors
- [ ] **Documentation** - wrote readable code & commits, documented unintuitive code
- [ ] **Testing** - unit & E2E test coverage, tested in staging, DB migrations backwards compatible
- [ ] **Security** - sanitized inputs, vetted dependencies, validated/secured API requests, no committed secrets
- [ ] **Performance** - optimized expensive algorithms & database queries

Please select all **applied** standards relevant to this PR.
## Confirmation

- [ ] **Assignee Confirmation** - I (the author) have filled out the template above
- [ ] **Reviewer Confirmation** - I (a/the reviewer) confirm 1) the author has filled out the template and checked the box that says **Assignee Confirmation** 2) I reviewed the code and selected all applicable items in the code review section.
